### PR TITLE
Remove STRING_DICT_UNARY references

### DIFF
--- a/skydoc/build.proto
+++ b/skydoc/build.proto
@@ -37,11 +37,13 @@ message Attribute {
     BOOLEAN = 14;            // int, bool and string value
     TRISTATE = 15;           // tristate, int and string value
     INTEGER_LIST = 16;       // int_list_value
-    STRING_DICT_UNARY = 17;  // string_dict_unary_value
     UNKNOWN = 18;            // unknown type, use only for build extensions
     LABEL_DICT_UNARY = 19;   // label_dict_unary_value
     SELECTOR_LIST = 20;      // selector_list
     NAME = 21;               // name, use only for the name attribute
+
+    // Deprecated.
+    DEPRECATED_STRING_DICT_UNARY = 17;
   }
 }
 

--- a/skydoc/rule.py
+++ b/skydoc/rule.py
@@ -73,8 +73,6 @@ class Attribute(object):
       type_str = 'Tristate'
     elif proto.type == build_pb2.Attribute.INTEGER_LIST:
       type_str = 'List of integers'
-    elif proto.type == build_pb2.Attribute.STRING_DICT_UNARY:
-      type_str = 'String Dict Unary'
     elif proto.type == build_pb2.Attribute.LABEL_DICT_UNARY:
       type_str = 'Label Dict Unary'
     elif proto.type == build_pb2.Attribute.SELECTOR_LIST:


### PR DESCRIPTION
Remove from code, deprecate in proto. This hasn't been used by bazel in a while.