### PR TITLE
add attr.label_keyed_string_dict (fixes #54)

### DIFF
--- a/skydoc/build.proto
+++ b/skydoc/build.proto
@@ -41,6 +41,7 @@ message Attribute {
     LABEL_DICT_UNARY = 19;   // label_dict_unary_value
     SELECTOR_LIST = 20;      // selector_list
     NAME = 21;               // name, use only for the name attribute
+    LABEL_KEYED_STRING_DICT = 22; // label_keyed_string_dict
 
     // Deprecated.
     DEPRECATED_STRING_DICT_UNARY = 17;

--- a/skydoc/rule.py
+++ b/skydoc/rule.py
@@ -77,6 +77,8 @@ class Attribute(object):
       type_str = 'Label Dict Unary'
     elif proto.type == build_pb2.Attribute.SELECTOR_LIST:
       type_str = 'Selector List'
+    elif proto.type == build_pb2.Attribute.LABEL_KEYED_STRING_DICT:
+      type_str = 'Dictionary mapping %s to strings' % self.LABELS_LINK
     else:
       if proto.name == 'name':
         type_str = self.NAME_LINK

--- a/skydoc/stubs/attr.py
+++ b/skydoc/stubs/attr.py
@@ -165,3 +165,11 @@ def string_list_dict(default={},
                      allow_empty=True):
   return AttrDescriptor(build_pb2.Attribute.STRING_LIST_DICT, repr(default),
                         mandatory)
+
+def label_keyed_string_dict(default={},
+                            mandatory=False,
+                            allow_files=False,
+                            non_empty=False,
+                            allow_empty=True):
+  return AttrDescriptor(build_pb2.Attribute.LABEL_KEYED_STRING_DICT, repr(default),
+                        mandatory)


### PR DESCRIPTION
I'm not sure if it matters that I've added this as 22 in the enum, but it's 21 in bazel proper: https://github.com/bazelbuild/bazel/blob/3759d00356e7bf1dcf42e34cb83ad7bf3153a9c2/src/main/protobuf/build.proto#L134