### PR TITLE
skylark_library srcs for skylark_doc

### DIFF
--- a/site/docs/generating.md
+++ b/site/docs/generating.md
@@ -104,7 +104,7 @@ load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_doc")
 
 skylark_doc(
     name = "docs",
-    deps = [
+    srcs = [
         "//checkstyle:checkstyle-rules",
         "//lua:lua-rules",
     ],
@@ -112,5 +112,5 @@ skylark_doc(
 ```
 
 Running `bazel build //:docs` would build a single zip containing documentation
-for all the `.bzl` files contained in the two `skylark_library` targets.
+for all the `.bzl` files contained in the two `skylark_library` targets' `srcs`.
 


### PR DESCRIPTION
Allows specification of `skylark_library` as `srcs`, causing those targets' `srcs` to be considered for doc generation. Tried it out manually by permuting `//skylark:skylark-docs` as follows

    skylark_doc(
         name = "skylark-docs-multiple",
         srcs = [":skylark"],
         overview = False,
         strip_prefix = "skylark",
    )

Fixes #78.