### PR TITLE
[Skydoc] Capture error before accessing it.

### DIFF
--- a/skydoc/load_extractor.py
+++ b/skydoc/load_extractor.py
@@ -67,7 +67,7 @@ class LoadExtractor(object):
           load_symbol = LoadSymbol(label, symbol, alias)
           load_symbols.append(load_symbol)
 
-    except IOError:
+    except IOError as e:
       print("Failed to parse {0}: {1}".format(bzl_file, e.strerror))
       pass
 


### PR DESCRIPTION
In case of parse errors, Skydoc is trying to access an error instance to print it,
but since it's not actually captured in `except` clause, this causes a runtime error.

The change is capturing the instance to prevent runtime error.