### PR TITLE
Refactor and update dependencies

### DIFF
--- a/skydoc/BUILD
+++ b/skydoc/BUILD
@@ -2,13 +2,13 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-load("@protobuf//:protobuf.bzl", "py_proto_library")
+load("@org_google_protobuf//:protobuf.bzl", "py_proto_library")
 
 py_proto_library(
     name = "build_pb_py",
     srcs = ["build.proto"],
-    default_runtime = "@protobuf//:protobuf_python",
-    protoc = "@protobuf//:protoc",
+    default_runtime = "@org_google_protobuf//:protobuf_python",
+    protoc = "@org_google_protobuf//:protoc",
 )
 
 py_library(
@@ -77,7 +77,7 @@ py_library(
     srcs = ["rule.py"],
     deps = [
         ":build_pb_py",
-        "//external:mistune",
+        "@org_mistune_mistune//:lib",
     ],
 )
 
@@ -94,7 +94,7 @@ py_binary(
         ":macro_extractor",
         ":rule",
         ":rule_extractor",
-        "//external:gflags",
-        "//external:jinja2",
+        "@org_abseil_absl_py//:lib",
+        "@org_jinja2_jinja2//:lib",
     ],
 )

--- a/skydoc/main.py
+++ b/skydoc/main.py
@@ -15,7 +15,6 @@
 """Documentation generator for Skylark"""
 
 # internal imports
-import gflags
 import jinja2
 import mistune
 import os
@@ -24,6 +23,7 @@ import shutil
 import sys
 import tempfile
 import zipfile
+from absl import flags
 
 from skydoc import common
 from skydoc import load_extractor
@@ -31,33 +31,33 @@ from skydoc import macro_extractor
 from skydoc import rule
 from skydoc import rule_extractor
 
-gflags.DEFINE_string('output_dir', '',
+flags.DEFINE_string('output_dir', '',
     'The directory to write the output generated documentation to if '
     '--zip=false')
-gflags.DEFINE_string('output_file', '',
+flags.DEFINE_string('output_file', '',
     'The output zip archive file to write if --zip=true.')
-gflags.DEFINE_string('format', 'markdown',
+flags.DEFINE_string('format', 'markdown',
     'The output format. Possible values are markdown and html')
-gflags.DEFINE_bool('zip', True,
+flags.DEFINE_bool('zip', True,
     'Whether to generate a ZIP arhive containing the output files. If '
     '--zip is true, then skydoc will generate a zip file, skydoc.zip by '
     'default or as specified by --output_file. If --zip is false, then '
     'skydoc will generate documentation, either in Markdown or HTML as '
     'specifed by --format, in the current directory or --output_dir if set.')
-gflags.DEFINE_string('strip_prefix', '',
+flags.DEFINE_string('strip_prefix', '',
     'The directory prefix to strip from all generated docs, which are '
     'generated in subdirectories that match the package structure of the '
     'input .bzl files. The prefix to strip must be common to all .bzl files; '
     'otherwise, skydoc will raise an error.')
-gflags.DEFINE_bool('overview', False, 'Whether to generate an overview page')
-gflags.DEFINE_string('overview_filename', 'index',
+flags.DEFINE_bool('overview', False, 'Whether to generate an overview page')
+flags.DEFINE_string('overview_filename', 'index',
     'The file name to use for the overview page.')
-gflags.DEFINE_string('link_ext', 'html',
+flags.DEFINE_string('link_ext', 'html',
     'The file extension used for links in the generated documentation')
-gflags.DEFINE_string('site_root', '',
+flags.DEFINE_string('site_root', '',
     'The site root to be prepended to all URLs in the generated documentation')
 
-FLAGS = gflags.FLAGS
+FLAGS = flags.FLAGS
 
 DEFAULT_OUTPUT_DIR = '.'
 DEFAULT_OUTPUT_FILE = 'skydoc.zip'

--- a/skydoc/rule_extractor.py
+++ b/skydoc/rule_extractor.py
@@ -39,6 +39,7 @@ SKYLARK_STUBS = {
     "repository_rule": skylark_globals.repository_rule,
     "rule": skylark_globals.rule,
     "load": skylark_globals.load,
+    "go_rule": skylark_globals.go_rule,
 }
 """Stubs for Skylark globals to be used to evaluate the .bzl file."""
 
@@ -66,9 +67,11 @@ def create_stubs(skylark_stubs, load_symbols):
   stubs = dict(skylark_stubs)
   for load_symbol in load_symbols:
     if load_symbol.alias:
-      stubs[load_symbol.alias] = ""
+      key = load_symbol.alias
     else:
-      stubs[load_symbol.symbol] = ""
+      key = load_symbol.symbol
+    if key not in stubs:
+      stubs[key] = ""
   return stubs
 
 

--- a/skydoc/stubs/skylark_globals.py
+++ b/skydoc/stubs/skylark_globals.py
@@ -41,6 +41,9 @@ def struct(**kwargs):
 def load(label, *args, **kwargs):
   return None
 
+def go_rule(label, **kwargs):
+  return None
+
 class Label(object):
   def __init__(self, label_string, relative_to_caller_repository=False):
     self.label_string = label_string

--- a/skylark/skylark.bzl
+++ b/skylark/skylark.bzl
@@ -162,131 +162,112 @@ Example:
 
 JINJA2_BUILD_FILE = """
 py_library(
-    name = "jinja2",
+    name = "lib",
     srcs = glob(["jinja2/*.py"]),
-    srcs_version = "PY2AND3",
-    deps = [
-        "@markupsafe_archive//:markupsafe",
-    ],
+    deps = ["@org_markupsafe_markupsafe//:lib"],
     visibility = ["//visibility:public"],
 )
 """
 
 MARKUPSAFE_BUILD_FILE = """
 py_library(
-    name = "markupsafe",
+    name = "lib",
     srcs = glob(["markupsafe/*.py"]),
-    srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )
 """
 
 MISTUNE_BUILD_FILE = """
 py_library(
-    name = "mistune",
+    name = "lib",
     srcs = ["mistune.py"],
-    srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )
 """
 
 SIX_BUILD_FILE = """
 py_library(
-    name = "six",
+    name = "lib",
     srcs = ["six.py"],
-    srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )
 """
 
-GFLAGS_BUILD_FILE = """
+ABSEIL_BUILD_FILE = """
 py_library(
-    name = "gflags",
-    srcs = [
-        "gflags.py",
-        "gflags_validators.py",
-    ],
+    name = "lib",
+    srcs = glob(["absl/**/*.py"]),
     visibility = ["//visibility:public"],
+    deps = ["@org_python_six//:lib"],
 )
 """
 
-def skydoc_repositories():
+def skydoc_repositories(exclude=[]):
   """Adds the external repositories used by the skylark rules."""
-  native.http_archive(
-      name = "protobuf",
-      url = "https://github.com/google/protobuf/archive/v3.4.1.tar.gz",
-      sha256 = "8e0236242106e680b4f9f576cc44b8cd711e948b20a9fc07769b0a20ceab9cc4",
-      strip_prefix = "protobuf-3.4.1",
-  )
+  if "org_google_protobuf" not in exclude:
+    native.http_archive(
+        name = "org_google_protobuf",
+        url = "https://github.com/google/protobuf/archive/v3.4.1.tar.gz",
+        sha256 = "8e0236242106e680b4f9f576cc44b8cd711e948b20a9fc07769b0a20ceab9cc4",
+        strip_prefix = "protobuf-3.4.1",
+    )
 
-  # Protobuf expects an //external:python_headers label which would contain the
-  # Python headers if fast Python protos is enabled. Since we are not using fast
-  # Python protos, bind python_headers to a dummy target.
-  native.bind(
-      name = "python_headers",
-      actual = "//:dummy",
-  )
+    # Protobuf expects an //external:python_headers label which would contain the
+    # Python headers if fast Python protos is enabled. Since we are not using fast
+    # Python protos, bind python_headers to a dummy target.
+    native.bind(
+        name = "python_headers",
+        actual = "//:dummy",
+    )
 
-  native.new_http_archive(
-      name = "markupsafe_archive",
-      url = "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz#md5=f5ab3deee4c37cd6a922fb81e730da6e",
-      sha256 = "a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3",
-      build_file_content = MARKUPSAFE_BUILD_FILE,
-      strip_prefix = "MarkupSafe-0.23",
-  )
+  if "org_python_six" not in exclude:
+    native.new_http_archive(
+        name = "org_python_six",
+        url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
+        sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
+        build_file_content = SIX_BUILD_FILE,
+        strip_prefix = "six-1.10.0",
+    )
 
-  native.bind(
-      name = "markupsafe",
-      actual = "@markupsafe_archive//:markupsafe",
-  )
+  if "org_python_six" not in exclude and "org_google_protobuf" not in exclude:
+    # Protobuf expects an //external:six label
+    native.bind(
+        name = "six",
+        actual = "@org_python_six//:lib",
+    )
 
-  native.new_http_archive(
-      name = "jinja2_archive",
-      url = "https://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.8.tar.gz#md5=edb51693fe22c53cee5403775c71a99e",
-      sha256 = "bc1ff2ff88dbfacefde4ddde471d1417d3b304e8df103a7a9437d47269201bf4",
-      build_file_content = JINJA2_BUILD_FILE,
-      strip_prefix = "Jinja2-2.8",
-  )
+  if "org_markupsafe_markupsafe" not in exclude:
+    native.new_http_archive(
+        name = "org_markupsafe_markupsafe",
+        url = "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz",
+        sha256 = "a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3",
+        build_file_content = MARKUPSAFE_BUILD_FILE,
+        strip_prefix = "MarkupSafe-0.23",
+    )
 
-  native.bind(
-      name = "jinja2",
-      actual = "@jinja2_archive//:jinja2",
-  )
+  if "org_jinja2_jinja2" not in exclude:
+    native.new_http_archive(
+        name = "org_jinja2_jinja2",
+        url = "https://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.8.tar.gz",
+        sha256 = "bc1ff2ff88dbfacefde4ddde471d1417d3b304e8df103a7a9437d47269201bf4",
+        build_file_content = JINJA2_BUILD_FILE,
+        strip_prefix = "Jinja2-2.8",
+    )
 
-  native.new_http_archive(
-      name = "mistune_archive",
-      url = "https://pypi.python.org/packages/source/m/mistune/mistune-0.7.1.tar.gz#md5=057bc28bf629d6a1283d680a34ed9d0f",
-      sha256 = "6076dedf768348927d991f4371e5a799c6a0158b16091df08ee85ee231d929a7",
-      build_file_content = MISTUNE_BUILD_FILE,
-      strip_prefix = "mistune-0.7.1",
-  )
+  if "org_mistune_mistune" not in exclude:
+    native.new_http_archive(
+        name = "org_mistune_mistune",
+        url = "https://pypi.python.org/packages/source/m/mistune/mistune-0.7.1.tar.gz",
+        sha256 = "6076dedf768348927d991f4371e5a799c6a0158b16091df08ee85ee231d929a7",
+        build_file_content = MISTUNE_BUILD_FILE,
+        strip_prefix = "mistune-0.7.1",
+    )
 
-  native.bind(
-      name = "mistune",
-      actual = "@mistune_archive//:mistune",
-  )
-
-  native.new_http_archive(
-      name = "six_archive",
-      url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55",
-      sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
-      build_file_content = SIX_BUILD_FILE,
-      strip_prefix = "six-1.10.0",
-  )
-
-  native.bind(
-      name = "six",
-      actual = "@six_archive//:six",
-  )
-
-  native.new_git_repository(
-      name = "gflags_repo",
-      remote = "https://github.com/google/python-gflags",
-      tag = "python-gflags-2.0",
-      build_file_content = GFLAGS_BUILD_FILE,
-  )
-
-  native.bind(
-      name = "gflags",
-      actual = "@gflags_repo//:gflags",
-  )
+  if "org_abseil_absl_py" not in exclude:
+    native.new_http_archive(
+        name = "org_abseil_absl_py",
+        url = "https://files.pythonhosted.org/packages/source/a/absl-py/absl-py-0.1.12.tar.gz",
+        sha256 = "1530c03b3566f24e9fcf20eadd60a792837899aef98e522f998fcebecf5df41b",
+        build_file_content = ABSEIL_BUILD_FILE,
+        strip_prefix = "absl-py-0.1.12",
+    )


### PR DESCRIPTION
By adding exclude to the skydoc_repositories macro, we can allow the
caller to sort out dependencies so that they can resolve any particular
versioning needs for their internal use and between other libraries.
This prevents polluting the global //external space, which is
discouraged.

The outstanding problem here is protobuf, which expects some things
(notably six) to be available in //external, but for now I've just let
the caller deal with that as well if they so choose. I'll file a
follow-up ticket (and patch?) with protobuf to sort this out.