### PR TITLE
Add support for extracting keyword args documentation

### DIFF
--- a/skydoc/common.py
+++ b/skydoc/common.py
@@ -83,7 +83,19 @@ def _parse_attribute_docs(attr_docs, lines, index):
       break
     # In practice, users sometimes add a "-" prefix, so we strip it even
     # though it is not recommended by the style guide
-    match = re.search(r"^\s*-?\s*([`\{\}\%\.\w]+):\s*(.*)", line)
+    pattern = re.compile(r"""
+        # Any amount of leading whitespace, plus an optional "-" prefix.
+        ^\s*-?\s*
+        # The attribute name, plus an optional "**" prefix for a **kwargs
+        # attribute.
+        ((?:\*\*)?[`\{\}\%\.\w\*]+)
+        # A colon plus any amount of whitespace to separate the attribute name
+        # from the description text.
+        :\s*
+        # The attribute description text.
+        (.*)
+    """, re.VERBOSE)
+    match = re.search(pattern, line)
     if match:  # We have found a new attribute
       if attr:
         attr_docs[attr] = escape(desc)

--- a/skydoc/macro_extractor.py
+++ b/skydoc/macro_extractor.py
@@ -103,6 +103,15 @@ class MacroDocExtractor(object):
         if attr.type == build_pb2.Attribute.BOOLEAN:
           attr.default = node.id
 
+    if stmt.args.kwarg:
+      attr = rule.attribute.add()
+      attr_name = '**' + stmt.args.kwarg
+      attr.name = attr_name
+      attr.mandatory = False
+      attr.type = build_pb2.Attribute.UNKNOWN
+      if attr_name in extracted_docs.attr_docs:
+        attr.documentation = extracted_docs.attr_docs[attr_name]
+
     for template, doc in extracted_docs.output_docs.iteritems():
       output = rule.output.add()
       output.template = template

--- a/skydoc/macro_extractor_test.py
+++ b/skydoc/macro_extractor_test.py
@@ -93,6 +93,54 @@ class MacroExtractorTest(unittest.TestCase):
 
     self.check_protos(src, expected)
 
+  def test_kwargs(self):
+    src = textwrap.dedent("""\
+        def with_keyword_args(name, foo=False, **kwargs):
+          \"\"\"A rule with keyword args.
+
+          Args:
+            name: A unique name for this rule.
+            foo: A test argument.
+            **kwargs: Keyword arguments.
+          \"\"\"
+          native.genrule(
+              name = name,
+              out = ["foo"],
+              cmd = "touch $@",
+              visibility = visibility,
+              **kwargs
+          )
+        """)
+
+    expected = textwrap.dedent("""\
+        rule {
+          name: "with_keyword_args"
+          documentation: "A rule with keyword args."
+          attribute {
+            name: "name"
+            type: UNKNOWN
+            mandatory: true
+            documentation: "A unique name for this rule."
+          }
+          attribute {
+            name: "foo"
+            type: BOOLEAN
+            mandatory: false
+            default: "False"
+            documentation: "A test argument."
+          }
+          attribute {
+            name: "**kwargs"
+            type: UNKNOWN
+            mandatory: false
+            documentation: "Keyword arguments."
+          }
+          type: MACRO
+        }
+        """)
+
+    self.check_protos(src, expected)
+
   def test_undocumented(self):
     src = textwrap.dedent("""\
         def undocumented(name, visibility=None):


### PR DESCRIPTION
Add support for extracting keyword args documentation

Rules can accept additional keyword-based args, commonly as "**kwargs". Docs for these were being appended to the docs for the arg immediately preceding the kwargs. This commit fixes that, and splits off the kwargs docs into their own section.