### PR TITLE
Initial checkin of stardoc.bzl: a rewrite of skydoc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,6 +11,16 @@ git_repository(
     remote = "https://github.com/bazelbuild/bazel-skylib.git",
     tag = "0.2.0",
 )
+git_repository(
+    name = "io_bazel",
+    remote = "https://github.com/bazelbuild/bazel.git",
+    commit = "b749ab1f8549cdad0a574c356a57fe7181b07851",
+)
+http_archive(
+    name = "com_google_protobuf",
+    strip_prefix = "protobuf-3.5.1",
+    urls = ["https://github.com/google/protobuf/archive/v3.5.1.zip"],
+)
 
 load("@io_bazel_rules_sass//sass:sass.bzl", "sass_repositories")
 sass_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,8 @@ git_repository(
 git_repository(
     name = "io_bazel",
     remote = "https://github.com/bazelbuild/bazel.git",
+    # TODO(cparsons): Depend on a release tag of bazel when there is
+    # a valid release containing an updated stardoc binary.
     commit = "b749ab1f8549cdad0a574c356a57fe7181b07851",
 )
 http_archive(

--- a/skylark/BUILD
+++ b/skylark/BUILD
@@ -4,11 +4,14 @@ package(default_visibility = ["//visibility:public"])
 
 load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
 load("//skylark:skylark.bzl", "skylark_doc")
+load("//skylark:skydoc.bzl", "skydoc")
 
 skylark_library(
-    name = "skylark",
-    srcs = ["skylark.bzl"],
-    deps = ["@bazel_skylib//:skylark_library"],
+    name = "skydoc_lib",
+    srcs = ["skydoc.bzl"],
+    deps = [
+        "@bazel_skylib//:skylark_library",
+    ],
 )
 
 skylark_doc(
@@ -17,4 +20,12 @@ skylark_doc(
     overview = False,
     strip_prefix = "skylark",
     deps = [":skylark"],
+)
+
+skydoc(
+    name = "skydoc_doc",
+    target_file = ":skydoc.bzl",
+    deps = [":skydoc_lib"],
+    rule_names = ["skydoc"],
+    out = "skydoc_doc.md",
 )

--- a/skylark/BUILD
+++ b/skylark/BUILD
@@ -7,6 +7,14 @@ load("//skylark:skylark.bzl", "skylark_doc")
 load("//skylark:skydoc.bzl", "skydoc")
 
 skylark_library(
+    name = "skylark",
+    srcs = ["skylark.bzl"],
+    deps = [
+        "@bazel_skylib//:skylark_library"
+    ],
+)
+
+skylark_library(
     name = "skydoc_lib",
     srcs = ["skydoc.bzl"],
     deps = [

--- a/skylark/BUILD
+++ b/skylark/BUILD
@@ -4,7 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
 load("//skylark:skylark.bzl", "skylark_doc")
-load("//skylark:skydoc.bzl", "skydoc")
+load("//skylark:stardoc.bzl", "stardoc")
 
 skylark_library(
     name = "skylark",
@@ -15,8 +15,8 @@ skylark_library(
 )
 
 skylark_library(
-    name = "skydoc_lib",
-    srcs = ["skydoc.bzl"],
+    name = "stardoc_lib",
+    srcs = ["stardoc.bzl"],
     deps = [
         "@bazel_skylib//:skylark_library",
     ],
@@ -30,10 +30,10 @@ skylark_doc(
     deps = [":skylark"],
 )
 
-skydoc(
-    name = "skydoc_doc",
-    target_file = ":skydoc.bzl",
-    deps = [":skydoc_lib"],
-    rule_names = ["skydoc"],
-    out = "skydoc_doc.md",
+stardoc(
+    name = "stardoc_doc",
+    input = ":stardoc.bzl",
+    deps = [":stardoc_lib"],
+    rule_names = ["stardoc"],
+    out = "stardoc_doc.md",
 )

--- a/skylark/BUILD
+++ b/skylark/BUILD
@@ -34,6 +34,6 @@ stardoc(
     name = "stardoc_doc",
     input = ":stardoc.bzl",
     deps = [":stardoc_lib"],
-    rule_names = ["stardoc"],
+    symbol_names = ["stardoc"],
     out = "stardoc_doc.md",
 )

--- a/skylark/skydoc.bzl
+++ b/skylark/skydoc.bzl
@@ -1,0 +1,79 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylark rule for skydoc: a documentation generator tool written in Java."""
+
+load("@bazel_skylib//:skylark_library.bzl", "SkylarkLibraryInfo")
+
+def _skydoc_impl(ctx):
+    """Implementation of the skydoc rule."""
+    out_file = ctx.outputs.out
+    input_files = depset(order = "postorder", direct = [ctx.files.target_file[0]], transitive = [
+        dep[SkylarkLibraryInfo].transitive_srcs
+        for dep in ctx.attr.deps
+    ])
+    args = [
+        str(ctx.files.target_file[0].owner),
+        ctx.outputs.out.path,
+    ] + ctx.attr.rule_names
+    skydoc = ctx.executable.skydoc
+    ctx.actions.run(
+        outputs = [out_file],
+        inputs = input_files,
+        executable = skydoc,
+        arguments = args,
+        mnemonic = "Skydoc",
+        progress_message = ("Generating Skylark doc for %s" %
+                            (ctx.label.name)),
+    )
+
+skydoc = rule(
+    _skydoc_impl,
+    doc = """
+Generates documentation for exported skylark rule definitions in a target skylark file.
+
+This rule is an experimental replacement for the existing skylark_doc rule. It generates
+documentation for rule definitions in a target .bzl file.
+""",
+    attrs = {
+        "target_file": attr.label(
+            doc = "The skylark file to generate documentation for.",
+            allow_files = [".bzl"],
+        ),
+        "deps": attr.label_list(
+            doc = "A list of skylark_library dependencies which target_file depends on.",
+            providers = [SkylarkLibraryInfo],
+            allow_files = False,
+        ),
+        "out": attr.output(
+            doc = "The file to which documentation will be output.",
+            mandatory = True,
+        ),
+        "rule_names": attr.string_list(
+            doc = """
+A list of rule names to generate documentation for. These should correspond to
+the names of exported symbols for rule definitions in the target file. If this list
+is empty, then documentation for all exported rule definitions will be generated.
+""",
+            default = [],
+        ),
+        "skydoc": attr.label(
+            doc = "The location of the skydoc tool.",
+            allow_files = True,
+            default = Label("@io_bazel//src/main/java/com/google/devtools/build/skydoc"),
+            cfg = "host",
+            executable = True,
+        ),
+    },
+)

--- a/skylark/stardoc.bzl
+++ b/skylark/stardoc.bzl
@@ -19,14 +19,14 @@ load("@bazel_skylib//:skylark_library.bzl", "SkylarkLibraryInfo")
 def _stardoc_impl(ctx):
     """Implementation of the stardoc rule."""
     out_file = ctx.outputs.out
-    input_files = depset(direct = [ctx.files.input[0]], transitive = [
+    input_files = depset(direct = [ctx.file.input], transitive = [
         dep[SkylarkLibraryInfo].transitive_srcs
         for dep in ctx.attr.deps
     ])
     args = [
-        str(ctx.files.input[0].owner),
+        str(ctx.file.input.owner),
         ctx.outputs.out.path,
-    ] + ctx.attr.rule_names
+    ] + ctx.attr.symbol_names
     stardoc = ctx.executable.stardoc
     ctx.actions.run(
         outputs = [out_file],
@@ -58,11 +58,11 @@ This rule is an experimental replacement for the existing skylark_doc rule.
             doc = "The (markdown) file to which documentation will be output.",
             mandatory = True,
         ),
-        "rule_names": attr.string_list(
+        "symbol_names": attr.string_list(
             doc = """
-A list of rule names to generate documentation for. These should correspond to
-the names of exported symbols for rule definitions in the input file. If this list
-is empty, then documentation for all exported rule definitions will be generated.
+A list of symbol names to generate documentation for. These should correspond to
+the names of rule definitions in the input file. If this list is empty, then
+documentation for all exported rule definitions will be generated.
 """,
             default = [],
         ),

--- a/skylark/stardoc.bzl
+++ b/skylark/stardoc.bzl
@@ -12,64 +12,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Skylark rule for skydoc: a documentation generator tool written in Java."""
+"""Starlark rule for stardoc: a documentation generator tool written in Java."""
 
 load("@bazel_skylib//:skylark_library.bzl", "SkylarkLibraryInfo")
 
-def _skydoc_impl(ctx):
-    """Implementation of the skydoc rule."""
+def _stardoc_impl(ctx):
+    """Implementation of the stardoc rule."""
     out_file = ctx.outputs.out
-    input_files = depset(order = "postorder", direct = [ctx.files.target_file[0]], transitive = [
+    input_files = depset(direct = [ctx.files.input[0]], transitive = [
         dep[SkylarkLibraryInfo].transitive_srcs
         for dep in ctx.attr.deps
     ])
     args = [
-        str(ctx.files.target_file[0].owner),
+        str(ctx.files.input[0].owner),
         ctx.outputs.out.path,
     ] + ctx.attr.rule_names
-    skydoc = ctx.executable.skydoc
+    stardoc = ctx.executable.stardoc
     ctx.actions.run(
         outputs = [out_file],
         inputs = input_files,
-        executable = skydoc,
+        executable = stardoc,
         arguments = args,
-        mnemonic = "Skydoc",
-        progress_message = ("Generating Skylark doc for %s" %
+        mnemonic = "Stardoc",
+        progress_message = ("Generating Starlark doc for %s" %
                             (ctx.label.name)),
     )
 
-skydoc = rule(
-    _skydoc_impl,
+stardoc = rule(
+    _stardoc_impl,
     doc = """
-Generates documentation for exported skylark rule definitions in a target skylark file.
+Generates documentation for exported skylark rule definitions in a target starlark file.
 
-This rule is an experimental replacement for the existing skylark_doc rule. It generates
-documentation for rule definitions in a target .bzl file.
+This rule is an experimental replacement for the existing skylark_doc rule.
 """,
     attrs = {
-        "target_file": attr.label(
-            doc = "The skylark file to generate documentation for.",
-            allow_files = [".bzl"],
+        "input": attr.label(
+            doc = "The starlark file to generate documentation for.",
+            allow_single_file = [".bzl"],
         ),
         "deps": attr.label_list(
-            doc = "A list of skylark_library dependencies which target_file depends on.",
+            doc = "A list of skylark_library dependencies which the input depends on.",
             providers = [SkylarkLibraryInfo],
-            allow_files = False,
         ),
         "out": attr.output(
-            doc = "The file to which documentation will be output.",
+            doc = "The (markdown) file to which documentation will be output.",
             mandatory = True,
         ),
         "rule_names": attr.string_list(
             doc = """
 A list of rule names to generate documentation for. These should correspond to
-the names of exported symbols for rule definitions in the target file. If this list
+the names of exported symbols for rule definitions in the input file. If this list
 is empty, then documentation for all exported rule definitions will be generated.
 """,
             default = [],
         ),
-        "skydoc": attr.label(
-            doc = "The location of the skydoc tool.",
+        "stardoc": attr.label(
+            doc = "The location of the stardoc tool.",
             allow_files = True,
             default = Label("@io_bazel//src/main/java/com/google/devtools/build/skydoc"),
             cfg = "host",

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,0 +1,14 @@
+licenses(["notice"])  # Apache 2.0
+
+sh_test(
+    name = "skydoc_self_gen_test",
+    srcs = ["diff_test_runner.sh"],
+    args = [
+        "$(location //skylark:skydoc_doc.md)",
+ 	"$(location :self_doc_golden.md)"
+    ],
+    data = [
+        ":self_doc_golden.md",
+        "//skylark:skydoc_doc.md",
+    ],
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -4,11 +4,11 @@ sh_test(
     name = "skydoc_self_gen_test",
     srcs = ["diff_test_runner.sh"],
     args = [
-        "$(location //skylark:skydoc_doc.md)",
- 	"$(location :self_doc_golden.md)"
+        "$(location //skylark:stardoc_doc.md)",
+        "$(location :self_doc_golden.md)"
     ],
     data = [
-        ":self_doc_golden.md",
-        "//skylark:skydoc_doc.md",
+        "self_doc_golden.md",
+        "//skylark:stardoc_doc.md",
     ],
 )

--- a/test/diff_test_runner.sh
+++ b/test/diff_test_runner.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# A shell test that the contents of an input file match a golden file.
+#
+# Usage: diff_test_runner.sh ACTUAL_FILE GOLDEN_FILE
+
+set -u
+
+actual_file=$1
+shift 1
+golden_file=$1
+shift 1
+
+DIFF="$(diff ${actual_file} ${golden_file})"
+
+if [ "$DIFF" != "" ]
+then
+    echo "Actual did not match golden."
+    echo "${DIFF}"
+    exit 1
+else
+    echo "Result matches golden file"
+fi

--- a/test/diff_test_runner.sh
+++ b/test/diff_test_runner.sh
@@ -29,9 +29,9 @@ DIFF="$(diff ${actual_file} ${golden_file})"
 
 if [ "$DIFF" != "" ]
 then
-    echo "Actual did not match golden."
+    echo "FAIL: Actual did not match golden."
     echo "${DIFF}"
     exit 1
 else
-    echo "Result matches golden file"
+    echo "SUCCESS: Result matches golden file"
 fi

--- a/test/self_doc_golden.md
+++ b/test/self_doc_golden.md
@@ -1,0 +1,82 @@
+<a name="#skydoc"></a>
+## skydoc
+
+<pre>
+skydoc(name, deps, out, rule_names, skydoc, target_file)
+</pre>
+
+
+Generates documentation for exported skylark rule definitions in a target skylark file.
+
+This rule is an experimental replacement for the existing skylark_doc rule. It generates
+documentation for rule definitions in a target .bzl file.
+
+
+### Attributes
+
+<table class="params-table">
+  <colgroup>
+    <col class="col-param" />
+    <col class="col-description" />
+  </colgroup>
+  <tbody>
+    <tr id="#skydoc_name">
+      <td><code>name</code></td>
+      <td>
+        String; required
+        <p>
+          A unique name for this rule.
+        </p>
+      </td>
+    </tr>
+    <tr id="#skydoc_deps">
+      <td><code>deps</code></td>
+      <td>
+        List of labels; optional
+        <p>
+          A list of skylark_library dependencies which target_file depends on.
+        </p>
+      </td>
+    </tr>
+    <tr id="#skydoc_out">
+      <td><code>out</code></td>
+      <td>
+        Label; required
+        <p>
+          The file to which documentation will be output.
+        </p>
+      </td>
+    </tr>
+    <tr id="#skydoc_rule_names">
+      <td><code>rule_names</code></td>
+      <td>
+        List of strings; optional
+        <p>
+          A list of rule names to generate documentation for. These should correspond to
+the names of exported symbols for rule definitions in the target file. If this list
+is empty, then documentation for all exported rule definitions will be generated.
+        </p>
+      </td>
+    </tr>
+    <tr id="#skydoc_skydoc">
+      <td><code>skydoc</code></td>
+      <td>
+        Label; optional
+        <p>
+          The location of the skydoc tool.
+        </p>
+      </td>
+    </tr>
+    <tr id="#skydoc_target_file">
+      <td><code>target_file</code></td>
+      <td>
+        Label; optional
+        <p>
+          The skylark file to generate documentation for.
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+

--- a/test/self_doc_golden.md
+++ b/test/self_doc_golden.md
@@ -1,15 +1,14 @@
-<a name="#skydoc"></a>
-## skydoc
+<a name="#stardoc"></a>
+## stardoc
 
 <pre>
-skydoc(name, deps, out, rule_names, skydoc, target_file)
+stardoc(name, deps, input, out, rule_names, stardoc)
 </pre>
 
 
-Generates documentation for exported skylark rule definitions in a target skylark file.
+Generates documentation for exported skylark rule definitions in a target starlark file.
 
-This rule is an experimental replacement for the existing skylark_doc rule. It generates
-documentation for rule definitions in a target .bzl file.
+This rule is an experimental replacement for the existing skylark_doc rule.
 
 
 ### Attributes
@@ -20,7 +19,7 @@ documentation for rule definitions in a target .bzl file.
     <col class="col-description" />
   </colgroup>
   <tbody>
-    <tr id="#skydoc_name">
+    <tr id="#stardoc_name">
       <td><code>name</code></td>
       <td>
         String; required
@@ -29,50 +28,50 @@ documentation for rule definitions in a target .bzl file.
         </p>
       </td>
     </tr>
-    <tr id="#skydoc_deps">
+    <tr id="#stardoc_deps">
       <td><code>deps</code></td>
       <td>
         List of labels; optional
         <p>
-          A list of skylark_library dependencies which target_file depends on.
+          A list of skylark_library dependencies which the input depends on.
         </p>
       </td>
     </tr>
-    <tr id="#skydoc_out">
+    <tr id="#stardoc_input">
+      <td><code>input</code></td>
+      <td>
+        Label; optional
+        <p>
+          The starlark file to generate documentation for.
+        </p>
+      </td>
+    </tr>
+    <tr id="#stardoc_out">
       <td><code>out</code></td>
       <td>
         Label; required
         <p>
-          The file to which documentation will be output.
+          The (markdown) file to which documentation will be output.
         </p>
       </td>
     </tr>
-    <tr id="#skydoc_rule_names">
+    <tr id="#stardoc_rule_names">
       <td><code>rule_names</code></td>
       <td>
         List of strings; optional
         <p>
           A list of rule names to generate documentation for. These should correspond to
-the names of exported symbols for rule definitions in the target file. If this list
+the names of exported symbols for rule definitions in the input file. If this list
 is empty, then documentation for all exported rule definitions will be generated.
         </p>
       </td>
     </tr>
-    <tr id="#skydoc_skydoc">
-      <td><code>skydoc</code></td>
+    <tr id="#stardoc_stardoc">
+      <td><code>stardoc</code></td>
       <td>
         Label; optional
         <p>
-          The location of the skydoc tool.
-        </p>
-      </td>
-    </tr>
-    <tr id="#skydoc_target_file">
-      <td><code>target_file</code></td>
-      <td>
-        Label; optional
-        <p>
-          The skylark file to generate documentation for.
+          The location of the stardoc tool.
         </p>
       </td>
     </tr>

--- a/test/self_doc_golden.md
+++ b/test/self_doc_golden.md
@@ -2,7 +2,7 @@
 ## stardoc
 
 <pre>
-stardoc(name, deps, input, out, rule_names, stardoc)
+stardoc(name, deps, input, out, stardoc, symbol_names)
 </pre>
 
 
@@ -55,23 +55,23 @@ This rule is an experimental replacement for the existing skylark_doc rule.
         </p>
       </td>
     </tr>
-    <tr id="#stardoc_rule_names">
-      <td><code>rule_names</code></td>
-      <td>
-        List of strings; optional
-        <p>
-          A list of rule names to generate documentation for. These should correspond to
-the names of exported symbols for rule definitions in the input file. If this list
-is empty, then documentation for all exported rule definitions will be generated.
-        </p>
-      </td>
-    </tr>
     <tr id="#stardoc_stardoc">
       <td><code>stardoc</code></td>
       <td>
         Label; optional
         <p>
           The location of the stardoc tool.
+        </p>
+      </td>
+    </tr>
+    <tr id="#stardoc_symbol_names">
+      <td><code>symbol_names</code></td>
+      <td>
+        List of strings; optional
+        <p>
+          A list of symbol names to generate documentation for. These should correspond to
+the names of rule definitions in the input file. If this list is empty, then
+documentation for all exported rule definitions will be generated.
         </p>
       </td>
     </tr>


### PR DESCRIPTION
My primary concern with this review is I'm having a tough time with naming. I hope we can soon deprecate and kill the old skydoc, so I'm hoping we can just call this new thing "Skydoc". I'm resistant to calling this experimental_skydoc or new_skydoc.

Maybe.. huh. Stardoc? >_>

Please give me your feedback :)