### PR TITLE
Make skydoc compatible with Python 3.

### DIFF
--- a/skydoc/BUILD
+++ b/skydoc/BUILD
@@ -94,7 +94,6 @@ py_binary(
         ":macro_extractor",
         ":rule",
         ":rule_extractor",
-        "//external:gflags",
         "//external:jinja2",
         "@bazel_tools//tools/python/runfiles",
     ],

--- a/skydoc/common.py
+++ b/skydoc/common.py
@@ -14,6 +14,7 @@
 
 """Common functions for skydoc."""
 
+import collections
 import re
 import textwrap
 from xml.sax.saxutils import escape
@@ -149,8 +150,8 @@ def parse_docstring(doc):
     The new documentation string and a dictionary that maps each attribute to
     its documentation
   """
-  attr_docs = {}
-  output_docs = {}
+  attr_docs = collections.OrderedDict() if hasattr(collections, 'OrderedDict') else {}
+  output_docs = collections.OrderedDict() if hasattr(collections, 'OrderedDict') else {}
   examples = []
   lines = doc.split("\n")
   docs = []

--- a/skydoc/load_extractor.py
+++ b/skydoc/load_extractor.py
@@ -63,7 +63,7 @@ class LoadExtractor(object):
         for arg in args[1:]:
           load_symbol = LoadSymbol(label, arg, None)
           load_symbols.append(load_symbol)
-        for alias, symbol in kwargs.iteritems():
+        for alias, symbol in kwargs.items():
           load_symbol = LoadSymbol(label, symbol, alias)
           load_symbols.append(load_symbol)
 

--- a/skydoc/load_extractor_test.py
+++ b/skydoc/load_extractor_test.py
@@ -22,7 +22,7 @@ from skydoc import load_extractor
 class LoadExtractorTest(unittest.TestCase):
 
   def check_symbols(self, src, expected):
-    with tempfile.NamedTemporaryFile() as tf:
+    with tempfile.NamedTemporaryFile(mode='w+') as tf:
       tf.write(src)
       tf.flush()
 
@@ -45,7 +45,7 @@ class LoadExtractorTest(unittest.TestCase):
     self.check_symbols(src, expected)
 
   def raises_error(self, src):
-    with tempfile.NamedTemporaryFile() as tf:
+    with tempfile.NamedTemporaryFile(mode='w+') as tf:
       tf.write(src)
       tf.flush()
 

--- a/skydoc/macro_extractor_test.py
+++ b/skydoc/macro_extractor_test.py
@@ -363,37 +363,37 @@ class MacroExtractorTest(unittest.TestCase):
         """)
 
     expected = textwrap.dedent("""\
-rule {
-  name: "macro_with_outputs"
-  documentation: "Macro with output documentation."
-  attribute {
-    name: "name"
-    type: UNKNOWN
-    mandatory: true
-    documentation: "A unique name for this rule."
-  }
-  attribute {
-    name: "foo"
-    type: UNKNOWN
-    mandatory: true
-    documentation: "A test argument."
-  }
-  attribute {
-    name: "visibility"
-    type: UNKNOWN
-    mandatory: false
-    documentation: "The visibility of this rule."
-  }
-  output {
-    template: "%{name}.jar"
-    documentation: "A Java archive."
-  }
-  output {
-    template: "%{name}_deploy.jar"
-    documentation: "A Java archive suitable for deployment.\\n\\nOnly built if explicitly requested."
-  }
-  type: MACRO
-}
+        rule {
+          name: "macro_with_outputs"
+          documentation: "Macro with output documentation."
+          attribute {
+            name: "name"
+            type: UNKNOWN
+            mandatory: true
+            documentation: "A unique name for this rule."
+          }
+          attribute {
+            name: "foo"
+            type: UNKNOWN
+            mandatory: true
+            documentation: "A test argument."
+          }
+          attribute {
+            name: "visibility"
+            type: UNKNOWN
+            mandatory: false
+            documentation: "The visibility of this rule."
+          }
+          output {
+            template: "%{name}.jar"
+            documentation: "A Java archive."
+          }
+          output {
+            template: "%{name}_deploy.jar"
+            documentation: "A Java archive suitable for deployment.\\n\\nOnly built if explicitly requested."
+          }
+          type: MACRO
+        }
         """)
 
     self.check_protos(src, expected)

--- a/skydoc/macro_extractor_test.py
+++ b/skydoc/macro_extractor_test.py
@@ -28,7 +28,7 @@ from skydoc import macro_extractor
 class MacroExtractorTest(unittest.TestCase):
 
   def check_protos(self, src, expected):
-    with tempfile.NamedTemporaryFile() as tf:
+    with tempfile.NamedTemporaryFile(mode='w+') as tf:
       tf.write(src)
       tf.flush()
 
@@ -363,37 +363,37 @@ class MacroExtractorTest(unittest.TestCase):
         """)
 
     expected = textwrap.dedent("""\
-        rule {
-          name: "macro_with_outputs"
-          documentation: "Macro with output documentation."
-          attribute {
-            name: "name"
-            type: UNKNOWN
-            mandatory: true
-            documentation: "A unique name for this rule."
-          }
-          attribute {
-            name: "foo"
-            type: UNKNOWN
-            mandatory: true
-            documentation: "A test argument."
-          }
-          attribute {
-            name: "visibility"
-            type: UNKNOWN
-            mandatory: false
-            documentation: "The visibility of this rule."
-          }
-          output {
-            template: "%{name}_deploy.jar"
-            documentation: "A Java archive suitable for deployment.\\n\\nOnly built if explicitly requested."
-          }
-          output {
-            template: "%{name}.jar"
-            documentation: "A Java archive."
-          }
-          type: MACRO
-        }
+rule {
+  name: "macro_with_outputs"
+  documentation: "Macro with output documentation."
+  attribute {
+    name: "name"
+    type: UNKNOWN
+    mandatory: true
+    documentation: "A unique name for this rule."
+  }
+  attribute {
+    name: "foo"
+    type: UNKNOWN
+    mandatory: true
+    documentation: "A test argument."
+  }
+  attribute {
+    name: "visibility"
+    type: UNKNOWN
+    mandatory: false
+    documentation: "The visibility of this rule."
+  }
+  output {
+    template: "%{name}.jar"
+    documentation: "A Java archive."
+  }
+  output {
+    template: "%{name}_deploy.jar"
+    documentation: "A Java archive suitable for deployment.\\n\\nOnly built if explicitly requested."
+  }
+  type: MACRO
+}
         """)
 
     self.check_protos(src, expected)
@@ -402,7 +402,7 @@ class MacroExtractorTest(unittest.TestCase):
     src = textwrap.dedent("""\
         \"\"\"Example rules\"\"\"
         """)
-    with tempfile.NamedTemporaryFile() as tf:
+    with tempfile.NamedTemporaryFile(mode='w+') as tf:
       tf.write(src)
       tf.flush()
 
@@ -420,7 +420,7 @@ class MacroExtractorTest(unittest.TestCase):
         Documentation continued here.
         \"\"\"
         """)
-    with tempfile.NamedTemporaryFile() as tf:
+    with tempfile.NamedTemporaryFile(mode='w+') as tf:
       tf.write(src)
       tf.flush()
 
@@ -441,7 +441,7 @@ class MacroExtractorTest(unittest.TestCase):
         Documentation continued here.
         \"\"\"
         """)
-    with tempfile.NamedTemporaryFile() as tf:
+    with tempfile.NamedTemporaryFile(mode='w+') as tf:
       tf.write(src)
       tf.flush()
 

--- a/skydoc/main.py
+++ b/skydoc/main.py
@@ -16,7 +16,6 @@
 
 from __future__ import print_function
 # internal imports
-import gflags
 import jinja2
 import mistune
 import os
@@ -27,40 +26,14 @@ import sys
 import tempfile
 import zipfile
 
+from optparse import OptionParser
+
 from bazel_tools.tools.python.runfiles import runfiles as runfiles_lib
 from skydoc import common
 from skydoc import load_extractor
 from skydoc import macro_extractor
 from skydoc import rule
 from skydoc import rule_extractor
-
-gflags.DEFINE_string('output_dir', '',
-    'The directory to write the output generated documentation to if '
-    '--zip=false')
-gflags.DEFINE_string('output_file', '',
-    'The output zip archive file to write if --zip=true.')
-gflags.DEFINE_string('format', 'markdown',
-    'The output format. Possible values are markdown and html')
-gflags.DEFINE_bool('zip', True,
-    'Whether to generate a ZIP arhive containing the output files. If '
-    '--zip is true, then skydoc will generate a zip file, skydoc.zip by '
-    'default or as specified by --output_file. If --zip is false, then '
-    'skydoc will generate documentation, either in Markdown or HTML as '
-    'specifed by --format, in the current directory or --output_dir if set.')
-gflags.DEFINE_string('strip_prefix', '',
-    'The directory prefix to strip from all generated docs, which are '
-    'generated in subdirectories that match the package structure of the '
-    'input .bzl files. The prefix to strip must be common to all .bzl files; '
-    'otherwise, skydoc will raise an error.')
-gflags.DEFINE_bool('overview', False, 'Whether to generate an overview page')
-gflags.DEFINE_string('overview_filename', 'index',
-    'The file name to use for the overview page.')
-gflags.DEFINE_string('link_ext', 'html',
-    'The file extension used for links in the generated documentation')
-gflags.DEFINE_string('site_root', '',
-    'The site root to be prepended to all URLs in the generated documentation')
-
-FLAGS = gflags.FLAGS
 
 DEFAULT_OUTPUT_DIR = '.'
 DEFAULT_OUTPUT_FILE = 'skydoc.zip'
@@ -254,18 +227,40 @@ class HtmlWriter(object):
     return (output_file, "%s.html" % self.__options.overview_filename)
 
 def main(argv):
-  if FLAGS.output_dir and FLAGS.output_file:
+  parser = OptionParser()
+  parser.add_option('--output_dir', default='', help='The directory to write the output generated documentation to if --zip=false')
+  parser.add_option('--output_file', default='', help='The output zip archive file to write if --zip=true.')
+  parser.add_option('--format', default='markdown', help='The output format. Possible values are markdown and html')
+  parser.add_option('--zip', action='store_true', default=True,
+    help='Whether to generate a ZIP arhive containing the output files. If '
+         '--zip is true, then skydoc will generate a zip file, skydoc.zip by '
+         'default or as specified by --output_file. If --zip is false, then '
+         'skydoc will generate documentation, either in Markdown or HTML as '
+         'specifed by --format, in the current directory or --output_dir if set.')
+  parser.add_option('--strip_prefix',
+    help='The directory prefix to strip from all generated docs, which are '
+         'generated in subdirectories that match the package structure of the '
+         'input .bzl files. The prefix to strip must be common to all .bzl files; '
+         'otherwise, skydoc will raise an error.')
+  parser.add_option('--overview', action='store_true', help='Whether to generate an overview page')
+  parser.add_option('--overview_filename', default='index', help='The file name to use for the overview page.')
+  parser.add_option('--link_ext', default='html', help='The file extension used for links in the generated documentation')
+  parser.add_option('--site_root', default='', help='The site root to be prepended to all URLs in the generated documentation')
+  (options, args) = parser.parse_args(argv)
+
+  if options.output_dir and options.output_file:
     sys.stderr.write('Only one of --output_dir or --output_file can be set.')
     sys.exit(1)
 
-  if not FLAGS.output_dir:
-    FLAGS.output_dir = DEFAULT_OUTPUT_DIR
-  if not FLAGS.output_file:
-    FLAGS.output_file = DEFAULT_OUTPUT_FILE
+  if not options.output_dir:
+    options.output_dir = DEFAULT_OUTPUT_DIR
+  if not options.output_file:
+    options.output_file = DEFAULT_OUTPUT_FILE
 
-  bzl_files = argv[1:]
+  bzl_files = args[1:]
+
   try:
-    strip_prefix = common.validate_strip_prefix(FLAGS.strip_prefix, bzl_files)
+    strip_prefix = common.validate_strip_prefix(options.strip_prefix, bzl_files)
   except common.InputError as err:
     print(err.message)
     sys.exit(1)
@@ -310,20 +305,20 @@ def main(argv):
     rulesets.append(
         rule.RuleSet(bzl_file, merged_language, macro_doc_extractor.title,
                      macro_doc_extractor.description, strip_prefix,
-                     FLAGS.format))
+                     options.format))
   writer_options = WriterOptions(
-      FLAGS.output_dir, FLAGS.output_file, FLAGS.zip, FLAGS.overview,
-      FLAGS.overview_filename, FLAGS.link_ext, FLAGS.site_root)
-  if FLAGS.format == "markdown":
+      options.output_dir, options.output_file, options.zip, options.overview,
+      options.overview_filename, options.link_ext, options.site_root)
+  if options.format == "markdown":
     markdown_writer = MarkdownWriter(writer_options, runfiles)
     markdown_writer.write(rulesets)
-  elif FLAGS.format == "html":
+  elif options.format == "html":
     html_writer = HtmlWriter(writer_options, runfiles)
     html_writer.write(rulesets)
   else:
     sys.stderr.write(
         'Invalid output format: %s. Possible values are markdown and html'
-        % FLAGS.format)
+        % options.format)
 
 if __name__ == '__main__':
-  main(FLAGS(sys.argv))
+  main(sys.argv)

--- a/skydoc/main.py
+++ b/skydoc/main.py
@@ -228,24 +228,31 @@ class HtmlWriter(object):
 
 def main(argv):
   parser = OptionParser()
-  parser.add_option('--output_dir', default='', help='The directory to write the output generated documentation to if --zip=false')
-  parser.add_option('--output_file', default='', help='The output zip archive file to write if --zip=true.')
-  parser.add_option('--format', default='markdown', help='The output format. Possible values are markdown and html')
+  parser.add_option('--output_dir', default='',
+      help='The directory to write the output generated documentation to if --zip=false')
+  parser.add_option('--output_file', default='',
+      help='The output zip archive file to write if --zip=true.')
+  parser.add_option('--format', default='markdown',
+      help='The output format. Possible values are markdown and html')
   parser.add_option('--zip', action='store_true', default=True,
-    help='Whether to generate a ZIP arhive containing the output files. If '
-         '--zip is true, then skydoc will generate a zip file, skydoc.zip by '
-         'default or as specified by --output_file. If --zip is false, then '
-         'skydoc will generate documentation, either in Markdown or HTML as '
-         'specifed by --format, in the current directory or --output_dir if set.')
+      help='Whether to generate a ZIP arhive containing the output files. If '
+           '--zip is true, then skydoc will generate a zip file, skydoc.zip by '
+           'default or as specified by --output_file. If --zip is false, then '
+           'skydoc will generate documentation, either in Markdown or HTML as '
+           'specifed by --format, in the current directory or --output_dir if set.')
   parser.add_option('--strip_prefix',
-    help='The directory prefix to strip from all generated docs, which are '
-         'generated in subdirectories that match the package structure of the '
-         'input .bzl files. The prefix to strip must be common to all .bzl files; '
-         'otherwise, skydoc will raise an error.')
-  parser.add_option('--overview', action='store_true', help='Whether to generate an overview page')
-  parser.add_option('--overview_filename', default='index', help='The file name to use for the overview page.')
-  parser.add_option('--link_ext', default='html', help='The file extension used for links in the generated documentation')
-  parser.add_option('--site_root', default='', help='The site root to be prepended to all URLs in the generated documentation')
+      help='The directory prefix to strip from all generated docs, which are '
+           'generated in subdirectories that match the package structure of the '
+           'input .bzl files. The prefix to strip must be common to all .bzl files; '
+           'otherwise, skydoc will raise an error.')
+  parser.add_option('--overview', action='store_true',
+      help='Whether to generate an overview page')
+  parser.add_option('--overview_filename', default='index',
+      help='The file name to use for the overview page.')
+  parser.add_option('--link_ext', default='html',
+      help='The file extension used for links in the generated documentation')
+  parser.add_option('--site_root', default='',
+      help='The site root to be prepended to all URLs in the generated documentation')
   (options, args) = parser.parse_args(argv)
 
   if options.output_dir and options.output_file:

--- a/skydoc/rule_extractor.py
+++ b/skydoc/rule_extractor.py
@@ -15,6 +15,7 @@
 """Extractor for Skylark rule documentation."""
 
 import ast
+import functools
 # internal imports
 
 from skydoc import build_pb2
@@ -98,10 +99,10 @@ class RuleDocExtractor(object):
       compiled = compile(f.read(), bzl_file, 'exec')
     global_stubs = create_stubs(SKYLARK_STUBS, load_symbols)
     env = global_stubs.copy()
-    exec(compiled) in env
+    exec(compiled, env)
 
     new_globals = (
-      defn for defn in env.iteritems() if not global_stubs.has_key(defn[0])
+      defn for defn in env.items() if not defn[0] in global_stubs
     )
     for name, obj in new_globals:
       if (isinstance(obj, skylark_globals.RuleDescriptor) and
@@ -126,14 +127,14 @@ class RuleDocExtractor(object):
       rule = self.__extracted_rules[name]
       rule.doc = extracted_docs.doc
       rule.example_doc = extracted_docs.example_doc
-      for attr_name, desc in extracted_docs.attr_docs.iteritems():
+      for attr_name, desc in extracted_docs.attr_docs.items():
         if attr_name in rule.attrs:
           rule.attrs[attr_name].doc = desc
 
       # Match the output name from the docstring with the corresponding output
       # template name extracted from rule() and store a mapping of output
       # template name to documentation.
-      for output_name, desc in extracted_docs.output_docs.iteritems():
+      for output_name, desc in extracted_docs.output_docs.items():
         if output_name in rule.outputs:
           output_template = rule.outputs[output_name]
           rule.output_docs[output_template] = desc
@@ -179,7 +180,7 @@ class RuleDocExtractor(object):
     from the .bzl file.
     """
     rules = []
-    for rule_name, rule_desc in self.__extracted_rules.iteritems():
+    for rule_name, rule_desc in self.__extracted_rules.items():
       rule_desc.name = rule_name
       rules.append(rule_desc)
     rules = sorted(rules, key=lambda rule_desc: rule_desc.name)
@@ -196,7 +197,7 @@ class RuleDocExtractor(object):
       if rule_desc.example_doc:
         rule.example_documentation = rule_desc.example_doc
 
-      attrs = sorted(rule_desc.attrs.values(), cmp=attr.attr_compare)
+      attrs = sorted(rule_desc.attrs.values(), key=functools.cmp_to_key(attr.attr_compare))
       for attr_desc in attrs:
         if attr_desc.name.startswith("_"):
           continue
@@ -209,7 +210,7 @@ class RuleDocExtractor(object):
         if attr_desc.default != None:
           attr_proto.default = attr_desc.default
 
-      for template, doc in rule_desc.output_docs.iteritems():
+      for template, doc in rule_desc.output_docs.items():
         output = rule.output.add()
         output.template = template
         output.documentation = doc

--- a/skydoc/rule_extractor_test.py
+++ b/skydoc/rule_extractor_test.py
@@ -47,7 +47,7 @@ class RuleExtractorTest(unittest.TestCase):
 
 
   def check_protos(self, src, expected, load_symbols=[]):
-    with tempfile.NamedTemporaryFile() as tf:
+    with tempfile.NamedTemporaryFile(mode='w+') as tf:
       tf.write(src)
       tf.flush()
 
@@ -570,12 +570,12 @@ class RuleExtractorTest(unittest.TestCase):
             default: "''"
           }
           output {
-            template: "%{name}_deploy.jar"
-            documentation: "A Java archive suitable for deployment.\\n\\nOnly built if explicitly requested."
-          }
-          output {
             template: "%{name}.jar"
             documentation: "A Java archive."
+          }
+          output {
+            template: "%{name}_deploy.jar"
+            documentation: "A Java archive suitable for deployment.\\n\\nOnly built if explicitly requested."
           }
           type: RULE
         }

--- a/skydoc/stubs/skylark_globals.py
+++ b/skydoc/stubs/skylark_globals.py
@@ -14,6 +14,8 @@
 
 """Stubs for Skylark globals"""
 
+import collections
+
 
 def FileType(filetypes=[]):
   return filetypes
@@ -91,9 +93,9 @@ class RuleDescriptor(object):
     self.doc = doc
     self.example_doc = ''
     self.outputs = outputs
-    self.output_docs = {}
+    self.output_docs = collections.OrderedDict() if hasattr(collections, 'OrderedDict') else {}
     self.type = type
-    for name, attr in self.attrs.iteritems():
+    for name, attr in self.attrs.items():
       attr.name = name
 
 def rule(implementation, test=False, attrs={}, outputs=None,

--- a/skylark/skylark.bzl
+++ b/skylark/skylark.bzl
@@ -207,17 +207,6 @@ py_library(
 )
 """
 
-GFLAGS_BUILD_FILE = """
-py_library(
-    name = "gflags",
-    srcs = [
-        "gflags.py",
-        "gflags_validators.py",
-    ],
-    visibility = ["//visibility:public"],
-)
-"""
-
 def skydoc_repositories():
     """Adds the external repositories used by the skylark rules."""
     http_archive(
@@ -285,17 +274,4 @@ def skydoc_repositories():
     native.bind(
         name = "six",
         actual = "@six_archive//:six",
-    )
-
-    http_archive(
-        name = "gflags_repo",
-        urls = ["https://github.com/google/python-gflags/archive/python-gflags-2.0.zip"],
-        sha256 = "344990e63d49b9b7a829aec37d5981d558fea12879f673ee7d25d2a109eb30ce",
-        build_file_content = GFLAGS_BUILD_FILE,
-        strip_prefix = "python-gflags-python-gflags-2.0",
-    )
-
-    native.bind(
-        name = "gflags",
-        actual = "@gflags_repo//:gflags",
     )


### PR DESCRIPTION
Also removes the dependency on python-gflags by replacing it with
optparse, which is available in the standard library of Python 2 and 3.

Where possible I wrote the code so that it doesn't even require Python
2.7, but should still work with even older versions. (OrderedDict only
ships starting with Python 2.7).

This also fixes a bug in skydoc in which the ordering of documentation
for outputs wasn't deterministic (because dicts in Python 2 didn't
preserve insertion order by default).

Tested with:

```
# This uses Python 2.7 on my Mac.
bazel test //...

# This uses Python 3.7 installed from Homebrew.
bazel test --python_path=/Users/philwo/homebrew/bin/python3.7 //...
```