### PR TITLE
Fix and enable tests on Windows

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,3 +15,8 @@ platforms:
     - "..."
     test_targets:
     - "..."
+  windows:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."

--- a/site/jekyll-tree.sh
+++ b/site/jekyll-tree.sh
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 set -eu
-set -x
 
 readonly OUTPUT=${PWD}/$1
 shift

--- a/site/jekyll-tree.sh
+++ b/site/jekyll-tree.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 set -eu
+set -x
 
 readonly OUTPUT=${PWD}/$1
 shift

--- a/site/jekyll-tree.sh
+++ b/site/jekyll-tree.sh
@@ -75,5 +75,6 @@ function main {
   unpack_skylark_doc
   include_skydoc_doc
   package_output
+  cd "$(dirname ${TMP})"
 }
 main

--- a/skydoc/load_extractor_test.py
+++ b/skydoc/load_extractor_test.py
@@ -22,14 +22,15 @@ from skydoc import load_extractor
 class LoadExtractorTest(unittest.TestCase):
 
   def check_symbols(self, src, expected):
-    with tempfile.NamedTemporaryFile(mode='w+') as tf:
-      tf.write(src)
-      tf.flush()
+    tf = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+    tf.write(src)
+    tf.flush()
+    tf.close()
+    extractor = load_extractor.LoadExtractor()
+    load_symbols = extractor.extract(tf.name)
+    os.remove(tf.name)
 
-      extractor = load_extractor.LoadExtractor()
-      load_symbols = extractor.extract(tf.name)
-
-      self.assertEqual(expected, load_symbols)
+    self.assertEqual(expected, load_symbols)
 
   def test_load(self):
     src = textwrap.dedent("""\
@@ -45,13 +46,15 @@ class LoadExtractorTest(unittest.TestCase):
     self.check_symbols(src, expected)
 
   def raises_error(self, src):
-    with tempfile.NamedTemporaryFile(mode='w+') as tf:
-      tf.write(src)
-      tf.flush()
+    tf = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+    tf.write(src)
+    tf.flush()
+    tf.close()
 
-      extractor = load_extractor.LoadExtractor()
-      self.assertRaises(load_extractor.LoadExtractorError,
-                        extractor.extract, tf.name)
+    extractor = load_extractor.LoadExtractor()
+    self.assertRaises(load_extractor.LoadExtractorError,
+                      extractor.extract, tf.name)
+    os.remove(tf.name)
 
   def test_invalid_non_string_literal_in_label(self):
     src = textwrap.dedent("""\

--- a/skydoc/macro_extractor_test.py
+++ b/skydoc/macro_extractor_test.py
@@ -28,17 +28,19 @@ from skydoc import macro_extractor
 class MacroExtractorTest(unittest.TestCase):
 
   def check_protos(self, src, expected):
-    with tempfile.NamedTemporaryFile(mode='w+') as tf:
-      tf.write(src)
-      tf.flush()
+    tf = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+    tf.write(src)
+    tf.flush()
+    tf.close()
 
-      expected_proto = build_pb2.BuildLanguage()
-      text_format.Merge(expected, expected_proto)
+    expected_proto = build_pb2.BuildLanguage()
+    text_format.Merge(expected, expected_proto)
 
-      extractor = macro_extractor.MacroDocExtractor()
-      extractor.parse_bzl(tf.name)
-      proto = extractor.proto()
-      self.assertEqual(expected_proto, proto)
+    extractor = macro_extractor.MacroDocExtractor()
+    extractor.parse_bzl(tf.name)
+    proto = extractor.proto()
+    os.remove(tf.name)
+    self.assertEqual(expected_proto, proto)
 
   def test_multi_line_description(self):
     src = textwrap.dedent("""\
@@ -402,14 +404,16 @@ class MacroExtractorTest(unittest.TestCase):
     src = textwrap.dedent("""\
         \"\"\"Example rules\"\"\"
         """)
-    with tempfile.NamedTemporaryFile(mode='w+') as tf:
-      tf.write(src)
-      tf.flush()
+    tf = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+    tf.write(src)
+    tf.flush()
+    tf.close()
 
-      extractor = macro_extractor.MacroDocExtractor()
-      extractor.parse_bzl(tf.name)
-      self.assertEqual('Example rules', extractor.title)
-      self.assertEqual('', extractor.description)
+    extractor = macro_extractor.MacroDocExtractor()
+    extractor.parse_bzl(tf.name)
+    os.remove(tf.name)
+    self.assertEqual('Example rules', extractor.title)
+    self.assertEqual('', extractor.description)
 
   def test_file_doc_title_description(self):
     src = textwrap.dedent("""\
@@ -420,16 +424,18 @@ class MacroExtractorTest(unittest.TestCase):
         Documentation continued here.
         \"\"\"
         """)
-    with tempfile.NamedTemporaryFile(mode='w+') as tf:
-      tf.write(src)
-      tf.flush()
+    tf = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+    tf.write(src)
+    tf.flush()
+    tf.close()
 
-      extractor = macro_extractor.MacroDocExtractor()
-      extractor.parse_bzl(tf.name)
-      self.assertEqual('Example rules', extractor.title)
-      self.assertEqual('This file contains example Bazel rules.'
-                       '\n\nDocumentation continued here.',
-                       extractor.description)
+    extractor = macro_extractor.MacroDocExtractor()
+    extractor.parse_bzl(tf.name)
+    os.remove(tf.name)
+    self.assertEqual('Example rules', extractor.title)
+    self.assertEqual('This file contains example Bazel rules.'
+                     '\n\nDocumentation continued here.',
+                     extractor.description)
 
   def test_file_doc_title_multiline(self):
     src = textwrap.dedent("""\
@@ -441,16 +447,18 @@ class MacroExtractorTest(unittest.TestCase):
         Documentation continued here.
         \"\"\"
         """)
-    with tempfile.NamedTemporaryFile(mode='w+') as tf:
-      tf.write(src)
-      tf.flush()
+    tf = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+    tf.write(src)
+    tf.flush()
+    tf.close()
 
-      extractor = macro_extractor.MacroDocExtractor()
-      extractor.parse_bzl(tf.name)
-      self.assertEqual('Example rules for Bazel', extractor.title)
-      self.assertEqual('This file contains example Bazel rules.'
-                       '\n\nDocumentation continued here.',
-                       extractor.description)
+    extractor = macro_extractor.MacroDocExtractor()
+    extractor.parse_bzl(tf.name)
+    os.remove(tf.name)
+    self.assertEqual('Example rules for Bazel', extractor.title)
+    self.assertEqual('This file contains example Bazel rules.'
+                     '\n\nDocumentation continued here.',
+                     extractor.description)
 
   def test_loads_ignored(self):
     src = textwrap.dedent("""\

--- a/skydoc/rule_extractor_test.py
+++ b/skydoc/rule_extractor_test.py
@@ -47,17 +47,19 @@ class RuleExtractorTest(unittest.TestCase):
 
 
   def check_protos(self, src, expected, load_symbols=[]):
-    with tempfile.NamedTemporaryFile(mode='w+') as tf:
-      tf.write(src)
-      tf.flush()
+    tf = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+    tf.write(src)
+    tf.flush()
+    tf.close()
 
-      expected_proto = build_pb2.BuildLanguage()
-      text_format.Merge(expected, expected_proto)
+    expected_proto = build_pb2.BuildLanguage()
+    text_format.Merge(expected, expected_proto)
 
-      extractor = rule_extractor.RuleDocExtractor()
-      extractor.parse_bzl(tf.name, load_symbols)
-      proto = extractor.proto()
-      self.assertEqual(expected_proto, proto)
+    extractor = rule_extractor.RuleDocExtractor()
+    extractor.parse_bzl(tf.name, load_symbols)
+    os.remove(tf.name)
+    proto = extractor.proto()
+    self.assertEqual(expected_proto, proto)
 
   def test_all_types(self):
     src = textwrap.dedent("""\


### PR DESCRIPTION
On Windows, you have to close a file before opening it anywhere else in Python. This is fixed by not using with statement in tests.