### PR TITLE
Use dep_roots flag of Stardoc

### DIFF
--- a/setup.bzl
+++ b/setup.bzl
@@ -63,7 +63,7 @@ def skydoc_repositories():
         name = "io_bazel",
         remote = "https://github.com/bazelbuild/bazel.git",
         # TODO: Update to a newer tagged version when available.
-        commit = "62675105d6a3bf879202e65fa576fa0ab0e7b467",  # Feb 7, 2019
+        commit = "436b0314cd6e4ac9aded5b318ac14b58ed95680e",  # Feb 11, 2019
     )
     _include_if_not_defined(
         http_archive,

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -38,7 +38,7 @@ def _stardoc_impl(ctx):
                  omit_if_empty = True)
     args.add_all(input_files,
                  format_each = "--dep_roots=%s",
-                 map_each = _root_from_path,
+                 map_each = _root_from_file,
                  omit_if_empty = True,
                  uniquify = True)
     args.add_all(ctx.attr.semantic_flags)

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -36,6 +36,13 @@ def _stardoc_impl(ctx):
     args.add_all(ctx.attr.symbol_names,
                  format_each = "--symbols=%s",
                  omit_if_empty = True)
+    # TODO(cparsons): Note that use of dep_roots alone does not guarantee
+    # the correct file is loaded. If two files exist under the same path
+    # but are under different roots, it is possible that Stardoc loads the
+    # one that is not explicitly an input to this action (if sandboxing is
+    # disabled). The correct way to resolve this is to explicitly specify
+    # the full set of transitive dependency Starlark files as action args
+    # (maybe using a param file), but this requires some work.
     args.add_all(input_files,
                  format_each = "--dep_roots=%s",
                  map_each = _root_from_file,

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -33,9 +33,12 @@ def _stardoc_impl(ctx):
     args = ctx.actions.args()
     args.add("--input=" + str(ctx.file.input.owner))
     args.add("--output=" + ctx.outputs.out.path)
-    args.add_all(ctx.attr.symbol_names,
-                 format_each = "--symbols=%s",
-                 omit_if_empty = True)
+    args.add_all(
+        ctx.attr.symbol_names,
+        format_each = "--symbols=%s",
+        omit_if_empty = True,
+    )
+
     # TODO(cparsons): Note that use of dep_roots alone does not guarantee
     # the correct file is loaded. If two files exist under the same path
     # but are under different roots, it is possible that Stardoc loads the
@@ -43,11 +46,13 @@ def _stardoc_impl(ctx):
     # disabled). The correct way to resolve this is to explicitly specify
     # the full set of transitive dependency Starlark files as action args
     # (maybe using a param file), but this requires some work.
-    args.add_all(input_files,
-                 format_each = "--dep_roots=%s",
-                 map_each = _root_from_file,
-                 omit_if_empty = True,
-                 uniquify = True)
+    args.add_all(
+        input_files,
+        format_each = "--dep_roots=%s",
+        map_each = _root_from_file,
+        omit_if_empty = True,
+        uniquify = True,
+    )
     args.add_all(ctx.attr.semantic_flags)
     stardoc = ctx.executable.stardoc
     ctx.actions.run(


### PR DESCRIPTION
This effectively passes all input file root information to Stardoc, and allows
Stardoc to depend on generated bzl files.

This commit has no test coverage, because appropriate test coverage should
live under @io_bazel where the Stardoc binary lives. Committing this is a
pre-requisite for depending on this new functionality from @io_bazel, so
appropriate test coverage in @io_bazel will follow shortly after this is
committed.