### PR TITLE
Update README and site with skydoc deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ details on the deprecation, and for some migration tips.
 
 ## Get Started
 
-* How to [set up Stardoc for your project](https://skydoc.bazel.build/docs/getting_started.html)
-* Writing [docstrings](https://skydoc.bazel.build/docs/writing.html)
-* How to [integrate Stardoc with your build](https://skydoc.bazel.build/docs/generating.html).
+* How to [set up Stardoc for your project](https://skydoc.bazel.build/docs/getting_started_stardoc.html)
+* Writing [docstrings](https://skydoc.bazel.build/docs/writing_stardoc.html)
+* How to [integrate Stardoc with your build](https://skydoc.bazel.build/docs/generating_stardoc.html).
 
 ## About Stardoc
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
-# [Skydoc](https://skydoc.bazel.build) - Skylark Documentation Generator
+# [Stardoc](https://skydoc.bazel.build) - Starlark Documentation Generator
 
 [![Build status](https://badge.buildkite.com/c793ed98a3802393dba9813f524bfe28a87da2ab235df38c49.svg)](https://buildkite.com/bazel/skydoc-postsubmit)
 
-Skydoc is a documentation generator for [Bazel](https://bazel.build) build rules
-written in [Skylark](https://bazel.build/docs/skylark/index.html).
+Stardoc is a documentation generator for [Bazel](https://bazel.build) build rules
+written in [Starlark](https://bazel.build/docs/skylark/index.html).
 
-Skydoc provides a Skylark rule (`skylark_doc`) that can be used to build documentation
-for Skylark rules in either Markdown or HTML. Skydoc generates one documentation page per
-`.bzl` file.
+Stardoc provides a Starlark rule (`stardoc`) that can be used to build documentation
+for Starlark rules in Markdown. Stardoc generates one documentation page per `.bzl` file.
 
-NOTE: `skylark_library`'s implementation has moved to
-[Skylib](https://github.com/bazelbuild/bazel-skylib#skylark_library).
+## Skydoc deprecation
 
-![A screenshot of Skydoc generated HTML documentation](https://raw.githubusercontent.com/bazelbuild/skydoc/master/skydoc-screenshot.png)
+NOTE: Stardoc is a replacement for the **deprecated** "Skydoc" documentation generator.
+
+See [Skydoc Deprecation](https://skydoc.bazel.build/docs/skydoc_deprecation.html) for
+details on the deprecation, and for some migration tips.
 
 ## Get Started
 
-* How to [set up Skydoc for your project](https://skydoc.bazel.build/docs/getting_started.html)
-* The Skydoc [docstring format](https://skydoc.bazel.build/docs/writing.html)
-* How to [integrate Skydoc with your build](https://skydoc.bazel.build/docs/generating.html).
+* How to [set up Stardoc for your project](https://skydoc.bazel.build/docs/getting_started.html)
+* Writing [docstrings](https://skydoc.bazel.build/docs/writing.html)
+* How to [integrate Stardoc with your build](https://skydoc.bazel.build/docs/generating.html).
 
-## About Skydoc
+## About Stardoc
 
-* How to [contribute to Skydoc](https://skydoc.bazel.build/contributing.html)
-* See the [Skydoc roadmap](https://skydoc.bazel.build/roadmap.html)
+* How to [contribute to Stardoc](https://skydoc.bazel.build/contributing.html)
+* See the [Stardoc roadmap](https://skydoc.bazel.build/roadmap.html)
+
+
+
+

--- a/site/_includes/drawer.html
+++ b/site/_includes/drawer.html
@@ -17,6 +17,7 @@
             <li>
               <span class="drawer-nav-title">Skydoc (deprecated)</span>
               <ul>
+                <li><a href="/docs/skydoc_deprecation.html">About Skydoc Deprecation</a></li>
                 <li><a href="/docs/getting_started.html">Getting Started</a></li>
                 <li><a href="/docs/writing.html">Writing Documentation</a></li>
                 <li><a href="/docs/generating.html">Generating Documentation</a></li>

--- a/site/docs/skydoc_deprecation.md
+++ b/site/docs/skydoc_deprecation.md
@@ -87,6 +87,7 @@ For example, suppose your `mypackage/foo.bzl` file depends on `other/package/bar
 depends on `third/package/baz.bzl`.
 
 **BUILD**:
+
 ```
 load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
 
@@ -97,7 +98,9 @@ stardoc(
     deps = ["//other/package:bar"],
 )
 ```
+
 **other/package/BUILD**:
+
 ```
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
@@ -107,7 +110,9 @@ bzl_library(
     deps = ["//third/package:baz"],
 )
 ```
+
 **third/package/BUILD**:
+
 ```
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 

--- a/site/docs/skydoc_deprecation.md
+++ b/site/docs/skydoc_deprecation.md
@@ -1,0 +1,127 @@
+---
+layout: default
+title: Skydoc deprecation
+stylesheet: docs
+---
+
+## Why was Skydoc deprecated?
+
+Skydoc functioned by evalutating Starlark files as if they were python. Unfortunately, while
+Starlark is **similar** to Python, there are some important syntactic differences between
+the languages. Assuming compatibility between the languages was inherently brittle, and resulted
+in a maintenance burden on the Starlark code. Specifically, if one of your transitive dependencies
+were to adopt a Starlark-compatible, python-incompatible construct, your Skydoc integration would
+break!
+
+Skydoc still exists as it's a nontrivial migration to Stardoc, but we plan on removing it
+in mid 2019.
+
+## How to migrate
+
+Stardoc is not a drop-in replacement for Skydoc. Its usage is slightly different, and it has some
+new features. It's recommended to take a look at the root Stardoc documentation, but here is
+a brief summary of some things to note for migration:
+
+### Docstring specification
+
+Stardoc uses inline documentation strings instead of python-style docstrings.
+For example, Skydoc documentation may have been specified with:
+
+```
+checkstyle = rule(
+    implementation = _impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = FileType([".java"]),
+        "deps": attr.label(),
+    },
+)
+"""Example rule documentation.
+
+Example:
+  Here is an example of how to use this rule.
+
+Args:
+  srcs: Source files used to build this target.
+  deps: Dependencies for this target.
+"""
+```
+
+...the equivalent for Stardoc is:
+
+```
+my_rule = rule(
+    implementation = _my_rule_impl,
+    doc = """
+Example rule documentation.
+
+Example:
+  Here is an example of how to use this rule.
+""",
+    attrs = {
+        "srcs" : attr.label_list(
+            doc = "Source files used to build this target.",
+        ),
+        "deps" : attr.label_list(
+            doc = "Dependencies for this target.",
+        ),
+    }
+)
+```
+
+### Different Starlark Rule
+
+Stardoc uses a different Starlark rule Skydoc with different attributes.
+
+See [Generating Documentation](https://skydoc.bazel.build/docs/generating_stardoc.html) for a
+tutorial on using the new rule, and the
+[Build Rule Reference](https://skydoc.bazel.build/docs/stardoc_reference.html) for information
+about the new `stardoc` rule itself.
+
+### Starlark Dependencies
+
+Stardoc depends on your `bzl` file, all of its dependencies, and all of its **transitive**
+dependencies, so that it can fully evaluate your Starlark code.
+`bazel-skylib`'s `bzl_library` is your "best friend" for tracking `bzl` dependencies.
+
+For example, suppose your `mypackage/foo.bzl` file depends on `other/package/bar.bzl`, which
+depends on `third/package/baz.bzl`.
+
+```
+# BUILD
+load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
+
+stardoc(
+    name = "foo_docs",
+    input = "foo.bzl",
+    out = "foo_doc.md",
+    deps = ["//other/package:bar"],
+)
+
+# other/package/BUILD
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "bar",
+    srcs = ["bar.bzl"],
+    deps = ["//third/package:baz"],
+)
+
+# third/package/BUILD
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "baz",
+    srcs = ["baz.bzl"],
+)
+```
+
+Thus, each dependency should have its own `bzl_library` target defined beside it, and it
+need only depend on the `bzl_library` targets corresponding to its direct dependencies.
+
+Unfortunately, this migration might involve creating a large number of `bzl_library` targets,
+but this work is useful beyond Stardoc. For example, `bzl_library` can be also used to gather
+transitive Starlark dependencies for use in shell tests or other test frameworks.
+
+See [Generating Documentation](https://skydoc.bazel.build/docs/generating_stardoc.html) for
+a tutorial.
+

--- a/site/docs/skydoc_deprecation.md
+++ b/site/docs/skydoc_deprecation.md
@@ -70,7 +70,7 @@ Example:
 
 ### Different Starlark Rule
 
-Stardoc uses a different Starlark rule Skydoc with different attributes.
+Stardoc uses a different Starlark rule than Skydoc with different attributes.
 
 See [Generating Documentation](https://skydoc.bazel.build/docs/generating_stardoc.html) for a
 tutorial on using the new rule, and the
@@ -86,8 +86,8 @@ dependencies, so that it can fully evaluate your Starlark code.
 For example, suppose your `mypackage/foo.bzl` file depends on `other/package/bar.bzl`, which
 depends on `third/package/baz.bzl`.
 
+**BUILD**:
 ```
-# BUILD
 load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
 
 stardoc(
@@ -96,8 +96,9 @@ stardoc(
     out = "foo_doc.md",
     deps = ["//other/package:bar"],
 )
-
-# other/package/BUILD
+```
+**other/package/BUILD**:
+```
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
@@ -105,8 +106,9 @@ bzl_library(
     srcs = ["bar.bzl"],
     deps = ["//third/package:baz"],
 )
-
-# third/package/BUILD
+```
+**third/package/BUILD**:
+```
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
@@ -115,10 +117,12 @@ bzl_library(
 )
 ```
 
-Thus, each dependency should have its own `bzl_library` target defined beside it, and it
-need only depend on the `bzl_library` targets corresponding to its direct dependencies.
+Thus, each `.bzl` file should appear in the `srcs` of a `bzl_library` target defined in the same
+package. The `deps` of this `bzl_library` should be (only) the `bzl_library` targets corresponding
+to the files that are _directly_ `load()`ed by the `srcs`. This structure mirrors that of other
+`<language>_library` rules in Bazel.
 
-Unfortunately, this migration might involve creating a large number of new `bzl_library` targets,
+This migration might involve creating a large number of new `bzl_library` targets,
 but this work is useful beyond Stardoc. For example, `bzl_library` can be also used to gather
 transitive Starlark dependencies for use in shell tests or other test frameworks.
 

--- a/site/docs/skydoc_deprecation.md
+++ b/site/docs/skydoc_deprecation.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Skydoc deprecation
+title: Skydoc Deprecation
 stylesheet: docs
 ---
 
@@ -118,10 +118,15 @@ bzl_library(
 Thus, each dependency should have its own `bzl_library` target defined beside it, and it
 need only depend on the `bzl_library` targets corresponding to its direct dependencies.
 
-Unfortunately, this migration might involve creating a large number of `bzl_library` targets,
+Unfortunately, this migration might involve creating a large number of new `bzl_library` targets,
 but this work is useful beyond Stardoc. For example, `bzl_library` can be also used to gather
 transitive Starlark dependencies for use in shell tests or other test frameworks.
 
 See [Generating Documentation](https://skydoc.bazel.build/docs/generating_stardoc.html) for
 a tutorial.
+
+## Migration Issues
+
+If you run into any issues migrating, please file a
+[github issue](https://github.com/bazelbuild/skydoc/issues).
 


### PR DESCRIPTION
* Update README to reference Stardoc instead of Skydoc
* Improve Skydoc-to-Stardoc migration documentation

Fixes #146 