### PR TITLE
Use a prebuilt Stardoc release binary

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,9 @@ node_repositories()
 load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 sass_repositories()
 
-
+#######################################################################
+##### MOST USERS SHOULD NOT NEED TO COPY ANYTHING BELOW THIS LINE #####
+#######################################################################
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 # Needed for skydoc only (not Stardoc), which is deprecated. Users should include
@@ -21,4 +23,11 @@ git_repository(
     name = "com_google_protobuf",
     remote = "https://github.com/protocolbuffers/protobuf.git",
     commit = "7b28271a61a3da0a37f6fda399b0c4c86464e5b3",  # 2018-11-16
+)
+
+# Needed for generating the Stardoc release binary.
+git_repository(
+    name = "io_bazel",
+    remote = "https://github.com/bazelbuild/bazel.git",
+    commit = "1488f91fec238adacbd0517fcee15d8ec0599b8d",  # Feb 27, 2019
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,5 +29,5 @@ git_repository(
 git_repository(
     name = "io_bazel",
     remote = "https://github.com/bazelbuild/bazel.git",
-    commit = "1488f91fec238adacbd0517fcee15d8ec0599b8d",  # Feb 27, 2019
+    commit = "49107ad79ef08811db22636928dfd113a9acf902",  # Mar 08, 2019
 )

--- a/setup.bzl
+++ b/setup.bzl
@@ -75,13 +75,6 @@ def skydoc_repositories():
         commit = "8ccf4f1c351928b55d5dddf3672e3667f6978d60",
     )
     _include_if_not_defined(
-        git_repository,
-        name = "io_bazel",
-        remote = "https://github.com/bazelbuild/bazel.git",
-        # TODO: Update to a newer tagged version when available.
-        commit = "1488f91fec238adacbd0517fcee15d8ec0599b8d",  # Feb 27, 2019
-    )
-    _include_if_not_defined(
         http_archive,
         name = "markupsafe_archive",
         urls = ["https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz#md5=f5ab3deee4c37cd6a922fb81e730da6e"],

--- a/stardoc/BUILD
+++ b/stardoc/BUILD
@@ -23,3 +23,17 @@ stardoc(
     ],
     deps = [":stardoc_lib"],
 )
+
+java_binary(
+    name = "stardoc",
+    main_class = "com.google.devtools.build.skydoc.SkydocMain",
+    runtime_deps = [
+        ":prebuilt_stardoc_binary",
+    ],
+)
+
+java_import(
+    name = "prebuilt_stardoc_binary",
+    jars = ["stardoc_binary.jar"],
+    visibility = ["//visibility:private"],
+)

--- a/stardoc/BUILD
+++ b/stardoc/BUILD
@@ -30,6 +30,14 @@ java_binary(
     runtime_deps = [
         ":prebuilt_stardoc_binary",
     ],
+    jvm_flags = [
+        # quiet warnings from com.google.protobuf.UnsafeUtil,
+        # see: https://github.com/google/protobuf/issues/3781
+        # TODO(cparsons): Remove once Stardoc has the fix.
+        "-XX:+IgnoreUnrecognizedVMOptions",
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    ],
 )
 
 java_import(

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -107,7 +107,7 @@ non-default semantic flags required to use the given Starlark symbols.
         "stardoc": attr.label(
             doc = "The location of the stardoc tool.",
             allow_files = True,
-            default = Label("@io_bazel//src/main/java/com/google/devtools/build/skydoc"),
+            default = Label("//stardoc:stardoc"),
             cfg = "host",
             executable = True,
         ),

--- a/update-release-binary.sh
+++ b/update-release-binary.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Renerates the Stardoc release binary from source in @io_bazel.
+#
+# This should only need to be run for cutting a new Stardoc release.
+
+set -eu
+
+echo "** Building Stardoc from source..."
+bazel build @io_bazel//src/main/java/com/google/devtools/build/skydoc:skydoc_deploy.jar
+
+echo "** Copying Stardoc binary..."
+cp bazel-bin/external/io_bazel/src/main/java/com/google/devtools/build/skydoc/skydoc_deploy.jar \
+    stardoc/stardoc_binary.jar
+
+echo "** Stardoc copied."


### PR DESCRIPTION
Instead of forcing users to depend on @io_bazel so that Stardoc
is built from source for each invocation, a prebuilt Stardoc binary will be included
in this repository, and updated on release cuts.

This also eliminates buggy behavior when Stardoc and @io_bazel repositories
are out of sync in a user's workspace.
