### PR TITLE
Pass --workspace_name to Stardoc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,5 +29,5 @@ git_repository(
 git_repository(
     name = "io_bazel",
     remote = "https://github.com/bazelbuild/bazel.git",
-    commit = "49107ad79ef08811db22636928dfd113a9acf902",  # Mar 08, 2019
+    commit = "c689bf93917ad0efa8100b3a0fe1b43f1f1a1cdf",  # Mar 19, 2019
 )

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -33,6 +33,7 @@ def _stardoc_impl(ctx):
     args = ctx.actions.args()
     args.add("--input=" + str(ctx.file.input.owner))
     args.add("--output=" + ctx.outputs.out.path)
+    args.add("--workspace_name=" + ctx.workspace_name)
     args.add_all(
         ctx.attr.symbol_names,
         format_each = "--symbols=%s",

--- a/test/self_doc_golden.md
+++ b/test/self_doc_golden.md
@@ -1,4 +1,7 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
 <a name="#stardoc"></a>
+
 ## stardoc
 
 <pre>
@@ -92,6 +95,8 @@ documentation for all exported rule definitions will be generated.
   </tbody>
 </table>
 
+
+<a name="#_stardoc_impl"></a>
 
 ## _stardoc_impl
 


### PR DESCRIPTION
Stardoc will thus avoid looking for dependencies in the current workspace name within external/.

For example, if the current workspace is "io_bazel", then, when a file loads "@io_bazel//foo:bar.bzl", Stardoc will look to foo/bar.bzl instead of external/io_bazel/foo/bar.bzl

Fixes #174 