### PR TITLE
Misc no-op fixes

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -20,3 +20,5 @@ platforms:
     - "..."
     test_targets:
     - "..."
+
+buildifier: latest

--- a/setup.bzl
+++ b/setup.bzl
@@ -18,7 +18,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _include_if_not_defined(repo_rule, name, **kwargs):
-    if name not in native.existing_rules():
+    if not native.existing_rule(name):
         repo_rule(name = name, **kwargs)
 
 JINJA2_BUILD_FILE = """

--- a/skydoc/BUILD
+++ b/skydoc/BUILD
@@ -19,6 +19,7 @@ py_library(
 py_test(
     name = "common_test",
     srcs = ["common_test.py"],
+    python_version = "PY2",
     deps = [
         ":common",
     ],
@@ -32,6 +33,7 @@ py_library(
 py_test(
     name = "load_extractor_test",
     srcs = ["load_extractor_test.py"],
+    python_version = "PY2",
     deps = [
         ":load_extractor",
     ],
@@ -46,6 +48,7 @@ py_library(
 py_test(
     name = "macro_extractor_test",
     srcs = ["macro_extractor_test.py"],
+    python_version = "PY2",
     deps = [
         ":build_pb_py",
         ":macro_extractor",
@@ -65,6 +68,7 @@ py_library(
 py_test(
     name = "rule_extractor_test",
     srcs = ["rule_extractor_test.py"],
+    python_version = "PY2",
     deps = [
         ":build_pb_py",
         ":load_extractor",
@@ -88,7 +92,9 @@ py_binary(
         "//skydoc/sass:main.css",
         "//skydoc/templates",
     ],
+    # no py_binary launcher
     main = "main.py",
+    python_version = "PY2",
     deps = [
         ":common",
         ":macro_extractor",

--- a/skylark/skylark.bzl
+++ b/skylark/skylark.bzl
@@ -14,8 +14,6 @@
 
 """Skylark rules"""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_skylib//:bzl_library.bzl", "StarlarkLibraryInfo")
 load("//:setup.bzl", _skydoc_repositories = "skydoc_repositories")
 

--- a/skylark/skylark.bzl
+++ b/skylark/skylark.bzl
@@ -25,6 +25,7 @@ def _skydoc(ctx):
     for f in ctx.files.skydoc:
         if not f.path.endswith(".py"):
             return f
+    fail("no valid .py file")
 
 def _skylark_doc_impl(ctx):
     """Implementation of the skylark_doc rule."""

--- a/skylark/skylark.bzl
+++ b/skylark/skylark.bzl
@@ -17,7 +17,7 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_skylib//:bzl_library.bzl", "StarlarkLibraryInfo")
-load("//:setup.bzl", _skydoc_repositories="skydoc_repositories")
+load("//:setup.bzl", _skydoc_repositories = "skydoc_repositories")
 
 _SKYLARK_FILETYPE = [".bzl"]
 

--- a/skylark/skylark.bzl
+++ b/skylark/skylark.bzl
@@ -97,6 +97,7 @@ skylark_doc = rule(
         "skylark_doc_zip": "%{name}-skydoc.zip",
     },
 )
+# buildozer: disable=no-effect
 """Generates Skylark rule documentation.
 
 Documentation is generated in directories that follows the package structure

--- a/stardoc/BUILD
+++ b/stardoc/BUILD
@@ -35,10 +35,6 @@ stardoc(
 
 java_binary(
     name = "stardoc",
-    main_class = "com.google.devtools.build.skydoc.SkydocMain",
-    runtime_deps = [
-        ":prebuilt_stardoc_binary",
-    ],
     jvm_flags = [
         # quiet warnings from com.google.protobuf.UnsafeUtil,
         # see: https://github.com/google/protobuf/issues/3781
@@ -46,6 +42,10 @@ java_binary(
         "-XX:+IgnoreUnrecognizedVMOptions",
         "--add-opens=java.base/java.nio=ALL-UNNAMED",
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    ],
+    main_class = "com.google.devtools.build.skydoc.SkydocMain",
+    runtime_deps = [
+        ":prebuilt_stardoc_binary",
     ],
 )
 


### PR DESCRIPTION
- Enable buildifier checks on Bazel CI
- Ran buildifier on a number of files
- py-related no-op attributes to be incompatible with some ongoing migrations