### PR TITLE
Add @rules_java repository to skydoc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.classpath
 /.factorypath
 /.idea/
+/.ijwb/
 /.project
 /.settings
 /WORKSPACE.user.bzl

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,8 @@
 workspace(name = "io_bazel_skydoc")
 
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 load(":setup.bzl", "skydoc_repositories")
 skydoc_repositories()
 
@@ -30,4 +33,27 @@ git_repository(
     name = "io_bazel",
     remote = "https://github.com/bazelbuild/bazel.git",
     commit = "ee0e62e239fee2853fec4b0deb794f3e464b6f93",  # Jul 02, 2019
+)
+
+maybe(
+    http_archive,
+    "rules_java",
+    sha256 = "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
+    urls = [
+      "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+      "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip"
+    ],
+    strip_prefix = "rules_java-7cf3cefd652008d0a64a419c34c13bdca6c8f178"
+)
+
+# Needed only because of java_tools.
+maybe(
+    http_archive,
+    "rules_cc",
+    sha256 = "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
+    urls = [
+      "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+      "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip"
+    ],
+    strip_prefix = "rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,18 +1,20 @@
 workspace(name = "io_bazel_skydoc")
 
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 load(":setup.bzl", "skydoc_repositories")
+
 skydoc_repositories()
 
 load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
+
 rules_sass_dependencies()
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+
 node_repositories()
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
+
 sass_repositories()
 
 #######################################################################
@@ -24,36 +26,34 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # this in their WORKSPACE only if they need skydoc.
 git_repository(
     name = "com_google_protobuf",
-    remote = "https://github.com/protocolbuffers/protobuf.git",
     commit = "7b28271a61a3da0a37f6fda399b0c4c86464e5b3",  # 2018-11-16
+    remote = "https://github.com/protocolbuffers/protobuf.git",
 )
 
 # Needed for generating the Stardoc release binary.
 git_repository(
     name = "io_bazel",
-    remote = "https://github.com/bazelbuild/bazel.git",
     commit = "ee0e62e239fee2853fec4b0deb794f3e464b6f93",  # Jul 02, 2019
+    remote = "https://github.com/bazelbuild/bazel.git",
 )
 
-maybe(
-    http_archive,
-    "rules_java",
+http_archive(
+    name = "rules_java",
     sha256 = "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
+    strip_prefix = "rules_java-7cf3cefd652008d0a64a419c34c13bdca6c8f178",
     urls = [
-      "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
-      "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip"
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+        "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
     ],
-    strip_prefix = "rules_java-7cf3cefd652008d0a64a419c34c13bdca6c8f178"
 )
 
 # Needed only because of java_tools.
-maybe(
-    http_archive,
-    "rules_cc",
+http_archive(
+    name = "rules_cc",
     sha256 = "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
-    urls = [
-      "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
-      "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip"
-    ],
     strip_prefix = "rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+        "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+    ],
 )

--- a/stardoc/BUILD
+++ b/stardoc/BUILD
@@ -4,6 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//stardoc:stardoc.bzl", "stardoc")
+load("@rules_java//java:defs.bzl", "java_binary", "java_import")
 
 filegroup(
     name = "test_deps",


### PR DESCRIPTION
This change is required before flipping `--incompatible_load_java_rules_from_bzl` in Bazel (see https://github.com/bazelbuild/bazel/issues/8746)