### PR TITLE
Escape default value and parameter documentation.

### DIFF
--- a/stardoc/templates/func.vm
+++ b/stardoc/templates/func.vm
@@ -21,11 +21,11 @@ ${util.htmlEscape($funcInfo.docString)}
     <tr id="${funcInfo.functionName}-${param.name}">
       <td><code>${param.name}</code></td>
       <td>
-        ${util.mandatoryString($param)}.#if(!$param.getDefaultValue().isEmpty()) default is <code>$param.getDefaultValue()</code>#end
+        ${util.mandatoryString($param)}.#if(!$param.getDefaultValue().isEmpty()) default is <code>${util.htmlEscape($param.getDefaultValue())}</code>#end
 
 #if (!$param.docString.isEmpty())
         <p>
-          ${param.docString.trim()}
+          ${util.htmlEscape($param.docString.trim())}
         </p>
 #end
       </td>


### PR DESCRIPTION
If a default value is "<tag>" or if a parameter docstring is something like "Creates a rule named <name>_derived." then the output markdown must encode the brackets correctly.

I've confirmed locally that this change fixes my use case.