### PR TITLE
Use ctx.label.workspace_name to retrieve current target workspace

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,3 +78,8 @@ http_archive(
     ],
 )
 
+# Needed only for testing stardoc across local-repository bounds.
+local_repository(
+    name = "local_repository_test",
+    path = "test/testdata/local_repository_test",
+)

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -32,7 +32,7 @@ def _stardoc_impl(ctx):
     ])
     stardoc_args = ctx.actions.args()
     stardoc_args.add("--input=" + str(ctx.file.input.owner))
-    stardoc_args.add("--workspace_name=" + ctx.workspace_name)
+    stardoc_args.add("--workspace_name=" + ctx.label.workspace_name)
     stardoc_args.add_all(
         ctx.attr.symbol_names,
         format_each = "--symbols=%s",
@@ -53,6 +53,13 @@ def _stardoc_impl(ctx):
         omit_if_empty = True,
         uniquify = True,
     )
+    # Needed in case some files are referenced across local repository
+    # namespace. For example, a file under a local repository @baz may
+    # be referenced as either //foo/bar:lib.bzl or @bar//:lib.bzl.
+    # If the stardoc target is under @bar, then both ./lib.bzl and
+    # external/bar/lib.bzl must be checked.
+    stardoc_args.add(
+        "--dep_roots=external/" + ctx.label.workspace_name)
     stardoc_args.add_all(ctx.attr.semantic_flags)
     stardoc = ctx.executable.stardoc
 

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -54,10 +54,11 @@ def _stardoc_impl(ctx):
         uniquify = True,
     )
     # Needed in case some files are referenced across local repository
-    # namespace. For example, a file under a local repository @baz may
-    # be referenced as either //foo/bar:lib.bzl or @bar//:lib.bzl.
-    # If the stardoc target is under @bar, then both ./lib.bzl and
-    # external/bar/lib.bzl must be checked.
+    # namespace. For example, consider a file under a local repository @bar
+    # which may be referenced as either //foo/bar:lib.bzl or @bar//:lib.bzl.
+    # If the stardoc target itself is under @bar, then both ./lib.bzl and
+    # external/bar/lib.bzl must be checked, depending on how the file
+    # is loaded.
     stardoc_args.add(
         "--dep_roots=external/" + ctx.label.workspace_name)
     stardoc_args.add_all(ctx.attr.semantic_flags)

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -54,11 +54,12 @@ def _stardoc_impl(ctx):
         uniquify = True,
     )
     # Needed in case some files are referenced across local repository
-    # namespace. For example, consider a file under a local repository @bar
-    # which may be referenced as either //foo/bar:lib.bzl or @bar//:lib.bzl.
-    # If the stardoc target itself is under @bar, then both ./lib.bzl and
-    # external/bar/lib.bzl must be checked, depending on how the file
-    # is loaded.
+    # namespace. For example, consider a file under a nested local repository @bar
+    # rooted under ./foo/bar/WORKSPACE. Consider a stardoc target 'lib_doc' under
+    # foo/bar/BUILD to document foo/bar/lib.bzl.
+    # The stardoc target references @bar//:lib.bzl (which appears just as :lib.bzl), but the
+    # actual build is taking place in the root repository, thus the source file
+    # is present under external/bar/lib.bzl.
     stardoc_args.add(
         "--dep_roots=external/" + ctx.label.workspace_name)
     stardoc_args.add_all(ctx.attr.semantic_flags)

--- a/test/BUILD
+++ b/test/BUILD
@@ -246,3 +246,16 @@ stardoc_test(
         "testdata/generated_bzl_test/dep.bzl",
     ],
 )
+
+sh_test(
+    name = "local_repository_test_e2e_test",
+    srcs = ["diff_test_runner.sh"],
+    args = [
+        "$(location @local_repository_test//:output.md)",
+        "$(location @local_repository_test//:golden.txt)",
+    ],
+    data = [
+        "@local_repository_test//:output.md",
+        "@local_repository_test//:golden.txt",
+    ],
+)

--- a/test/testdata/local_repository_test/BUILD
+++ b/test/testdata/local_repository_test/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["input.bzl", "golden.txt"])
+
+stardoc(
+    name = "input_doc",
+    out = "output.md",
+    input = ":input.bzl",
+)

--- a/test/testdata/local_repository_test/WORKSPACE
+++ b/test/testdata/local_repository_test/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "local_workspace_test")

--- a/test/testdata/local_repository_test/golden.txt
+++ b/test/testdata/local_repository_test/golden.txt
@@ -1,0 +1,33 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+<a name="#min"></a>
+
+## min
+
+<pre>
+min(<a href="#min-integers">integers</a>)
+</pre>
+
+Returns the minimum of given elements.
+
+### Parameters
+
+<table class="params-table">
+  <colgroup>
+    <col class="col-param" />
+    <col class="col-description" />
+  </colgroup>
+  <tbody>
+    <tr id="min-integers">
+      <td><code>integers</code></td>
+      <td>
+        required.
+        <p>
+          A list of integers. Must not be empty.
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+

--- a/test/testdata/local_repository_test/input.bzl
+++ b/test/testdata/local_repository_test/input.bzl
@@ -1,0 +1,15 @@
+"""A test that verifies documenting functions in an input file under a local_repository."""
+
+def min(integers):
+    """Returns the minimum of given elements.
+
+    Args:
+      integers: A list of integers. Must not be empty.
+
+    Returns:
+      The minimum integer in the given list.
+    """
+    _ignore = [integers]
+    return 42
+
+


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/skydoc/issues/233